### PR TITLE
Support for MsSQL IDENTITY

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,12 @@ For both of bulk operations you can provide data as an argument of method. The a
 
 #### Primary key generating
 
-Kros.KORM supports generating of primary keys for inserted records. Primary key must be simple `Int32` column. Primary key property in POCO class must be decorated by `Key` attribute and its property `AutoIncrementMethodType` must be set to `Custom`.
+Kros.KORM supports generating of primary keys for inserted records.
+
+Support two types of generating:
+1. Custom
+
+Primary key must be simple `Int32` column. Primary key property in POCO class must be decorated by `Key` attribute and its property `AutoIncrementMethodType` must be set to `Custom`.
 
 ```c#
 [Key(autoIncrementMethodType: AutoIncrementMethodType.Custom)]
@@ -394,6 +399,28 @@ public int Id { get; set; }
 ```
 
 Kros.KORM generates primary key for every inserted record, that does not have value for primary key property. For generating primary keys implementations of [IIdGenerator](https://kros-sk.github.io/Kros.Libs.Documentation/api/Kros.Utils/Kros.Data.IIdGenerator.html) are used.
+
+2. Identity
+
+When you set  `AutoIncrementMethodType` to `Identity`, Kros.KORM use `MsSql Identity` for generating primary key and fill generated keys into entity.
+```sql
+CREATE TABLE [dbo].[Users](
+	[Id] [int] IDENTITY(1,1) NOT NULL,
+	[FIrstName] [nvarchar](50) NULL,
+ CONSTRAINT [PK_Users] PRIMARY KEY CLUSTERED
+(
+	[Id] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+```
+
+```c#
+[Key(autoIncrementMethodType: AutoIncrementMethodType.Identity)]
+public int Id { get; set; }
+```
+
+When you call `dbSet.CommitChanges()`, Kros.KORM fill generated keys into entity. Unfortunately, he doesn't know it when you call a method `dbSet.BulkInsert()`.
+
 
 #### Editing records in database
 

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Kros.KORM generates primary key for every inserted record, that does not have va
 When you set  `AutoIncrementMethodType` to `Identity`, Kros.KORM use `MsSql Identity` for generating primary key and fill generated keys into entity.
 ```sql
 CREATE TABLE [dbo].[Users](
-	[Id] [int] IDENTITY(1,1) NOT NULL,
+	[Id] [bigint] IDENTITY(1,1) NOT NULL,
 	[FIrstName] [nvarchar](50) NULL,
  CONSTRAINT [PK_Users] PRIMARY KEY CLUSTERED
 (
@@ -416,10 +416,10 @@ CREATE TABLE [dbo].[Users](
 
 ```c#
 [Key(autoIncrementMethodType: AutoIncrementMethodType.Identity)]
-public int Id { get; set; }
+public long Id { get; set; }
 ```
 
-When you call `dbSet.CommitChanges()`, Kros.KORM fill generated keys into entity. Unfortunately, he doesn't know it when you call a method `dbSet.BulkInsert()`.
+When you call `dbSet.CommitChanges()`, Kros.KORM fill generated keys into entity. Unfortunately, doesn't know it when you call a method `dbSet.BulkInsert()`.
 
 
 #### Editing records in database

--- a/src/Metadata/AutoIncrementMethodType.cs
+++ b/src/Metadata/AutoIncrementMethodType.cs
@@ -22,8 +22,8 @@ namespace Kros.KORM.Metadata
 
         /// <summary>
         /// Sql server generates the primary key and KORM fills it into the entity.
+        /// When calling <see cref="IDbSet{T}.BulkInsert()"/> keys are not fill back to the entities.
         /// </summary>
-        /// <remarks>When calling <see cref="IDbSet.BulkInsert"/> keys are not fill back to the entities.</remarks>
-        Indetity = 2
+        Identity = 2
     }
 }

--- a/src/Metadata/AutoIncrementMethodType.cs
+++ b/src/Metadata/AutoIncrementMethodType.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Kros.KORM.Query;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -22,6 +23,7 @@ namespace Kros.KORM.Metadata
         /// <summary>
         /// Sql server generates the primary key and KORM fills it into the entity.
         /// </summary>
+        /// <remarks>When calling <see cref="IDbSet.BulkInsert"/> keys are not fill back to the entities.</remarks>
         Indetity = 2
     }
 }

--- a/src/Metadata/AutoIncrementMethodType.cs
+++ b/src/Metadata/AutoIncrementMethodType.cs
@@ -18,5 +18,10 @@ namespace Kros.KORM.Metadata
         /// KORM generate primary key for entity.
         /// </summary>
         Custom = 1,
+
+        /// <summary>
+        /// Sql server generates the primary key and KORM fills it into the entity.
+        /// </summary>
+        Indetity = 2
     }
 }

--- a/src/Metadata/TableInfo.cs
+++ b/src/Metadata/TableInfo.cs
@@ -16,6 +16,7 @@ namespace Kros.KORM.Metadata
 
         private Dictionary<string, ColumnInfo> _columns;
         private Lazy<Dictionary<string, ColumnInfo>> _properties;
+        private Lazy<ColumnInfo> _identityPrimaryKey;
 
         #endregion
 
@@ -46,6 +47,9 @@ namespace Kros.KORM.Metadata
                    _columns.ToDictionary(columnInfo => columnInfo.Value.PropertyInfo.Name,
                            columnInfo => columnInfo.Value,
                            StringComparer.CurrentCultureIgnoreCase));
+
+            _identityPrimaryKey = new Lazy<ColumnInfo>(()
+                => PrimaryKey.FirstOrDefault(p => p.AutoIncrementMethodType == AutoIncrementMethodType.Indetity));
         }
 
         #endregion
@@ -81,6 +85,17 @@ namespace Kros.KORM.Metadata
         /// The columns.
         /// </value>
         public IEnumerable<ColumnInfo> Columns => _columns.Values;
+
+        /// <summary>
+        /// Column info, which is mark as <see cref="AutoIncrementMethodType.Indetity"/>.
+        /// <see langword="null"/> if no one of primary keys is mark.
+        /// </summary>
+        public ColumnInfo IdentityPrimaryKey => _identityPrimaryKey.Value;
+
+        /// <summary>
+        /// Has table primary key mark as <see cref="AutoIncrementMethodType.Indetity"/>?
+        /// </summary>
+        public bool HasIdentityPrimaryKey => IdentityPrimaryKey != null;
 
         #endregion
 

--- a/src/Metadata/TableInfo.cs
+++ b/src/Metadata/TableInfo.cs
@@ -49,7 +49,7 @@ namespace Kros.KORM.Metadata
                            StringComparer.CurrentCultureIgnoreCase));
 
             _identityPrimaryKey = new Lazy<ColumnInfo>(()
-                => PrimaryKey.FirstOrDefault(p => p.AutoIncrementMethodType == AutoIncrementMethodType.Indetity));
+                => PrimaryKey.FirstOrDefault(p => p.AutoIncrementMethodType == AutoIncrementMethodType.Identity));
         }
 
         #endregion
@@ -87,13 +87,13 @@ namespace Kros.KORM.Metadata
         public IEnumerable<ColumnInfo> Columns => _columns.Values;
 
         /// <summary>
-        /// Column info, which is mark as <see cref="AutoIncrementMethodType.Indetity"/>.
+        /// Column info, which is mark as <see cref="AutoIncrementMethodType.Identity"/>.
         /// <see langword="null"/> if no one of primary keys is mark.
         /// </summary>
         public ColumnInfo IdentityPrimaryKey => _identityPrimaryKey.Value;
 
         /// <summary>
-        /// Has table primary key mark as <see cref="AutoIncrementMethodType.Indetity"/>?
+        /// Has table primary key mark as <see cref="AutoIncrementMethodType.Identity"/>?
         /// </summary>
         public bool HasIdentityPrimaryKey => IdentityPrimaryKey != null;
 

--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -296,6 +296,15 @@ namespace Kros.KORM.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The provider &apos;{0}&apos; does not support inserting values into table which model &apos;{1}&apos; has set primary key as Identity..
+        /// </summary>
+        internal static string ProviderDoesNotSupportIdentity {
+            get {
+                return ResourceManager.GetString("ProviderDoesNotSupportIdentity", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The method &apos;{0}&apos; is not supported..
         /// </summary>
         internal static string QueryGeneratorMethodNotSupported {

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -193,6 +193,9 @@
   <data name="ParameterDataTypeNotSet" xml:space="preserve">
     <value>Data type of the parameter must be set, when its value is NULL. Parameter name: {0}.</value>
   </data>
+  <data name="ProviderDoesNotSupportIdentity" xml:space="preserve">
+    <value>The provider '{0}' does not support inserting values into table which model '{1}' has set primary key as Identity.</value>
+  </data>
   <data name="QueryGeneratorMethodNotSupported" xml:space="preserve">
     <value>The method '{0}' is not supported.</value>
   </data>

--- a/src/Query/DbSet.cs
+++ b/src/Query/DbSet.cs
@@ -295,7 +295,7 @@ namespace Kros.KORM.Query
                         _commandGenerator.FillCommand(command, item);
                         if (hasIdentity)
                         {
-                            var id = 1;
+                            var id = await ExecuteScalarAsync(command, useAsync);
                             _tableInfo.IdentityPrimaryKey.SetValue(item, id);
                         }
                         else
@@ -328,6 +328,18 @@ namespace Kros.KORM.Query
             else
             {
                 _provider.ExecuteNonQueryCommand(command);
+            }
+        }
+
+        private async Task<object> ExecuteScalarAsync(DbCommand command, bool useAsync)
+        {
+            if (useAsync)
+            {
+                return await _provider.ExecuteScalarCommandAsync(command);
+            }
+            else
+            {
+                return _provider.ExecuteScalarCommand(command);
             }
         }
 

--- a/src/Query/DbSet.cs
+++ b/src/Query/DbSet.cs
@@ -284,17 +284,39 @@ namespace Kros.KORM.Query
         {
             if (items?.Count > 0)
             {
-                GeneratePrimaryKeys(items);
+                GenerateCustomPrimaryKeys(items);
+                bool hasIdentity = CheckIfCanUseIdentityPrimaryKey();
+
                 using (DbCommand command = _commandGenerator.GetInsertCommand())
                 {
                     PrepareCommand(command);
                     foreach (T item in items)
                     {
                         _commandGenerator.FillCommand(command, item);
-                        await ExecuteNonQueryAsync(command, useAsync);
+                        if (hasIdentity)
+                        {
+                            var id = 1;
+                            _tableInfo.IdentityPrimaryKey.SetValue(item, id);
+                        }
+                        else
+                        {
+                            await ExecuteNonQueryAsync(command, useAsync);
+                        }
                     }
                 }
             }
+        }
+
+        private bool CheckIfCanUseIdentityPrimaryKey()
+        {
+            var hasIdentity = _tableInfo.HasIdentityPrimaryKey;
+            if (hasIdentity && !_provider.SupportIdentity())
+            {
+                throw new InvalidOperationException(
+                    string.Format(Resources.ProviderDoesNotSupportIdentity, _provider.GetType().Name, typeof(T).Name));
+            }
+
+            return hasIdentity;
         }
 
         private async Task ExecuteNonQueryAsync(DbCommand command, bool useAsync)
@@ -309,7 +331,7 @@ namespace Kros.KORM.Query
             }
         }
 
-        private void GeneratePrimaryKeys(HashSet<T> items)
+        private void GenerateCustomPrimaryKeys(HashSet<T> items)
         {
             if (CanGeneratePrimaryKeys())
             {

--- a/src/Query/DbSet.cs
+++ b/src/Query/DbSet.cs
@@ -310,7 +310,7 @@ namespace Kros.KORM.Query
         private bool CheckIfCanUseIdentityPrimaryKey()
         {
             var hasIdentity = _tableInfo.HasIdentityPrimaryKey;
-            if (hasIdentity && !_provider.SupportIdentity())
+            if (hasIdentity && !_provider.SupportsIdentity())
             {
                 throw new InvalidOperationException(
                     string.Format(Resources.ProviderDoesNotSupportIdentity, _provider.GetType().Name, typeof(T).Name));

--- a/src/Query/Providers/IQueryProvider.cs
+++ b/src/Query/Providers/IQueryProvider.cs
@@ -40,6 +40,28 @@ namespace Kros.KORM.Query
         object ExecuteScalar<T>(IQuery<T> query);
 
         /// <summary>
+        /// Executes the query, and returns the first column of the first row in the result
+        /// set returned by the query. Additional columns or rows are ignored.
+        /// </summary>
+        /// <param name="command">The command.</param>
+        /// <returns>
+        /// The first column of the first row in the result set, or a null reference
+        /// (Nothingin Visual Basic) if the result set is empty.
+        /// </returns>
+        object ExecuteScalarCommand(IDbCommand command);
+
+        /// <summary>
+        /// Asynchronously executes the query, and returns the first column of the first row in the result
+        /// set returned by the query. Additional columns or rows are ignored.
+        /// </summary>
+        /// <param name="command">The command.</param>
+        /// <returns>
+        /// The first column of the first row in the result set, or a null reference
+        /// (Nothingin Visual Basic) if the result set is empty.
+        /// </returns>
+        Task<object> ExecuteScalarCommandAsync(DbCommand command);
+
+        /// <summary>
         /// Asynchronously executes action in transaction.
         /// </summary>
         /// <param name="action">Action which will be executed.</param>

--- a/src/Query/Providers/IQueryProvider.cs
+++ b/src/Query/Providers/IQueryProvider.cs
@@ -104,7 +104,7 @@ namespace Kros.KORM.Query
         /// <returns>
         /// <see langword="true"/> if provider supports inserting into table, where primary key is set as identity.
         /// </returns>
-        bool SupportIdentity();
+        bool SupportsIdentity();
 
         /// <summary>
         /// Sets correct data type to <paramref name="parameter"/>, according to column <paramref name="columnName"/>

--- a/src/Query/Providers/IQueryProvider.cs
+++ b/src/Query/Providers/IQueryProvider.cs
@@ -73,8 +73,16 @@ namespace Kros.KORM.Query
         /// <summary>
         /// Returns, if provider supports peparing of command (<see cref="DbCommand.Prepare"/>).
         /// </summary>
-        /// <returns><see langword="true"/> is provider supports preparing command, otherwise <see langword="false"/>.</returns>
+        /// <returns><see langword="true"/> if provider supports preparing command, otherwise <see langword="false"/>.</returns>
         bool SupportsPrepareCommand();
+
+        /// <summary>
+        /// Returns, if provider support inserting into table, where primary key is set as Identity.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> if provider supports inserting into table, where primary key is set as identity.
+        /// </returns>
+        bool SupportIdentity();
 
         /// <summary>
         /// Sets correct data type to <paramref name="parameter"/>, according to column <paramref name="columnName"/>

--- a/src/Query/Providers/QueryProvider.cs
+++ b/src/Query/Providers/QueryProvider.cs
@@ -270,6 +270,24 @@ namespace Kros.KORM.Query
         }
 
         /// <inheritdoc/>
+        public object ExecuteScalarCommand(IDbCommand command)
+        {
+            Check.NotNull(command, nameof(command));
+            _logger.LogCommand(command);
+
+            return command.ExecuteScalar();
+        }
+
+        /// <inheritdoc/>
+        public async Task<object> ExecuteScalarCommandAsync(DbCommand command)
+        {
+            Check.NotNull(command, nameof(command));
+            _logger.LogCommand(command);
+
+            return await command.ExecuteScalarAsync();
+        }
+
+        /// <inheritdoc/>
         public async Task ExecuteInTransactionAsync(Func<Task> action)
         {
             using (OpenConnection())

--- a/src/Query/Providers/QueryProvider.cs
+++ b/src/Query/Providers/QueryProvider.cs
@@ -178,6 +178,12 @@ namespace Kros.KORM.Query
         /// <returns>Returns <see langword="true"/>.</returns>
         public virtual bool SupportsPrepareCommand() => true;
 
+        /// <summary>
+        /// Returns, if provider support inserting into table, where primary key is set as Identity.
+        /// </summary>
+        /// <returns>Returns <see langword="true"/>.</returns>
+        public virtual bool SupportIdentity() => true;
+
         /// <inheritdoc cref="IQueryProvider.SetParameterDbType(DbParameter, string, string)"/>
         public void SetParameterDbType(DbParameter parameter, string tableName, string columnName)
         {

--- a/src/Query/Providers/QueryProvider.cs
+++ b/src/Query/Providers/QueryProvider.cs
@@ -182,7 +182,7 @@ namespace Kros.KORM.Query
         /// Returns, if provider support inserting into table, where primary key is set as Identity.
         /// </summary>
         /// <returns>Returns <see langword="true"/>.</returns>
-        public virtual bool SupportIdentity() => true;
+        public virtual bool SupportsIdentity() => true;
 
         /// <inheritdoc cref="IQueryProvider.SetParameterDbType(DbParameter, string, string)"/>
         public void SetParameterDbType(DbParameter parameter, string tableName, string columnName)

--- a/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
+++ b/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
@@ -7,7 +7,6 @@ using Kros.KORM.Metadata;
 using Kros.KORM.Metadata.Attribute;
 using Kros.KORM.Query;
 using Kros.KORM.Query.Providers;
-using Kros.KORM.Query.Sql;
 using NSubstitute;
 using System;
 using System.Collections.Generic;
@@ -29,6 +28,16 @@ namespace Kros.KORM.UnitTests.CommandGenerator
             const string expectedQuery = "INSERT INTO [Foo] ([IdRow], [Salary]) VALUES (@IdRow, @Salary)";
 
             DbCommand insert = GetFooGenerator().GetInsertCommand();
+
+            insert.CommandText.Should().Be(expectedQuery);
+        }
+
+        [Fact]
+        public void HaveCorrectInsertCommandTextWhenTableHaveIdentityPrimaryKey()
+        {
+            const string expectedQuery = "INSERT INTO [FooIdentity] ([Salary]) OUTPUT INSERTED.IdRow VALUES (@Salary)";
+
+            DbCommand insert = GetFooIdentityGenerator().GetInsertCommand();
 
             insert.CommandText.Should().Be(expectedQuery);
         }
@@ -221,6 +230,40 @@ namespace Kros.KORM.UnitTests.CommandGenerator
             return new TableInfo(columns, new List<PropertyInfo>(), null) { Name = "Foo" };
         }
 
+        private CommandGenerator<FooIdentity> GetFooIdentityGenerator()
+        {
+            var provider = Substitute.For<KORM.Query.IQueryProvider>();
+            provider.GetCommandForCurrentTransaction().Returns(a => { return new SqlCommand(); });
+
+            var query = CreateFooIdentityQuery();
+            query.Select(p => new { p.Id, p.Plat });
+            return new CommandGenerator<FooIdentity>(GetFooIdentityTableInfo(), provider, query);
+        }
+
+        private IQuery<FooIdentity> CreateFooIdentityQuery()
+        {
+            Query<FooIdentity> query = new Query<FooIdentity>(
+                new DatabaseMapper(new ConventionModelMapper()),
+                new SqlServerQueryProvider(
+                    new SqlConnection(),
+                    new SqlServerSqlExpressionVisitorFactory(new DatabaseMapper(new ConventionModelMapper())),
+                    Substitute.For<IModelBuilder>(),
+                    new Logger()));
+
+            return query;
+        }
+
+        private TableInfo GetFooIdentityTableInfo()
+        {
+            var columns = new List<ColumnInfo>() {
+                new ColumnInfo() { Name = "IdRow", PropertyInfo = GetPropertyInfo<Foo>("Id"),
+                    IsPrimaryKey = true, AutoIncrementMethodType = AutoIncrementMethodType.Indetity },
+                new ColumnInfo() { Name = "Salary", PropertyInfo = GetPropertyInfo<Foo>("Plat")}
+            };
+
+            return new TableInfo(columns, new List<PropertyInfo>(), null) { Name = "FooIdentity" };
+        }
+
         private List<Foo> GetFooList(int itemsCount)
         {
             List<Foo> retVal = new List<Foo>();
@@ -266,6 +309,16 @@ namespace Kros.KORM.UnitTests.CommandGenerator
 
             [Converter(typeof(TestEnumConverter))]
             public TestEnum PropertyEnumConv { get; set; }
+        }
+
+        private class FooIdentity
+        {
+            [Alias("IdRow")]
+            [Key(AutoIncrementMethodType.Indetity)]
+            public int Id { get; set; }
+
+            [Alias("Salary")]
+            public decimal Plat { get; set; }
         }
 
         private enum TestEnum

--- a/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
+++ b/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
@@ -257,7 +257,7 @@ namespace Kros.KORM.UnitTests.CommandGenerator
         {
             var columns = new List<ColumnInfo>() {
                 new ColumnInfo() { Name = "IdRow", PropertyInfo = GetPropertyInfo<Foo>("Id"),
-                    IsPrimaryKey = true, AutoIncrementMethodType = AutoIncrementMethodType.Indetity },
+                    IsPrimaryKey = true, AutoIncrementMethodType = AutoIncrementMethodType.Identity },
                 new ColumnInfo() { Name = "Salary", PropertyInfo = GetPropertyInfo<Foo>("Plat")}
             };
 
@@ -314,7 +314,7 @@ namespace Kros.KORM.UnitTests.CommandGenerator
         private class FooIdentity
         {
             [Alias("IdRow")]
-            [Key(AutoIncrementMethodType.Indetity)]
+            [Key(AutoIncrementMethodType.Identity)]
             public int Id { get; set; }
 
             [Alias("Salary")]

--- a/tests/Kros.KORM.UnitTests/Integration/PrimaryKeyGenerationTests.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/PrimaryKeyGenerationTests.cs
@@ -46,7 +46,7 @@ $@"CREATE TABLE[dbo].[People] (
 ) ON [PRIMARY];";
 
         private static readonly string CreateTable_Foo =
-$@"CREATE TABLE[dbo].[People] (
+$@"CREATE TABLE[dbo].[Foo] (
     [FooId] [bigint] IDENTITY(1,1) NOT NULL,
     [Value] [nvarchar](50) NULL,
 
@@ -103,7 +103,7 @@ INSERT INTO People VALUES ('Thomas');";
         [Fact]
         public async Task DbSetShoulFillGeneratedIdsIntoEntitiesWhenPrimaryKeyHasDifferentName()
         {
-            using (var korm = CreateDatabase(CreateTable_People))
+            using (var korm = CreateDatabase(CreateTable_Foo))
             {
                 var data = new List<Foo>() {
                     new Foo() { Value = "Bar 1" },

--- a/tests/Kros.KORM.UnitTests/Integration/PrimaryKeyGenerationTests.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/PrimaryKeyGenerationTests.cs
@@ -17,7 +17,7 @@ namespace Kros.KORM.UnitTests.Integration
         [Alias("People")]
         public class Person
         {
-            [Key("PK", AutoIncrementMethodType.Indetity)]
+            [Key("PK", AutoIncrementMethodType.Identity)]
             public int Id { get; set; }
 
             public string Name { get; set; }
@@ -25,7 +25,7 @@ namespace Kros.KORM.UnitTests.Integration
 
         public class Foo
         {
-            [Key("PK", AutoIncrementMethodType.Indetity)]
+            [Key("PK", AutoIncrementMethodType.Identity)]
             public long FooId { get; set; }
 
             public string Value { get; set; }

--- a/tests/Kros.KORM.UnitTests/Integration/PrimaryKeyGenerationTests.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/PrimaryKeyGenerationTests.cs
@@ -1,0 +1,122 @@
+﻿using FluentAssertions;
+using Kros.KORM.Metadata;
+using Kros.KORM.Metadata.Attribute;
+using Kros.KORM.Query;
+using Kros.KORM.UnitTests.Base;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kros.KORM.UnitTests.Integration
+{
+    public class PrimaryKeyGenerationTests : DatabaseTestBase
+    {
+        #region Nested Classes
+
+        [Alias("People")]
+        public class Person
+        {
+            [Key("PK", AutoIncrementMethodType.Indetity)]
+            public int Id { get; set; }
+
+            public string Name { get; set; }
+        }
+
+        public class Foo
+        {
+            [Key("PK", AutoIncrementMethodType.Indetity)]
+            public long FooId { get; set; }
+
+            public string Value { get; set; }
+        }
+
+        #endregion
+
+
+        #region SQL Scripts
+
+        private static readonly string CreateTable_People =
+$@"CREATE TABLE[dbo].[People] (
+    [Id] [int] IDENTITY(1,1) NOT NULL,
+    [Name] [nvarchar](50) NULL,
+
+     CONSTRAINT [PK_Person] PRIMARY KEY CLUSTERED ([Id] ASC) ON [PRIMARY]
+
+) ON [PRIMARY];";
+
+        private static readonly string CreateTable_Foo =
+$@"CREATE TABLE[dbo].[People] (
+    [FooId] [bigint] IDENTITY(1,1) NOT NULL,
+    [Value] [nvarchar](50) NULL,
+
+     CONSTRAINT [PK_Foo] PRIMARY KEY CLUSTERED ([FooId] ASC) ON [PRIMARY]
+
+) ON [PRIMARY];";
+
+        private static readonly string InsertDataScript =
+$@"INSERT INTO People VALUES ('John');
+INSERT INTO People VALUES ('Michael');
+INSERT INTO People VALUES ('Thomas');";
+
+        #endregion
+
+        [Fact]
+        public async Task DbSetShoulFillGeneratedIdsIntoEntities()
+        {
+            using (var korm = CreateDatabase(CreateTable_People))
+            {
+                var people = new List<Person>() {
+                    new Person() { Name = "Milan" },
+                    new Person() { Name = "Peter" }
+                };
+
+                IDbSet<Person> dbSet = korm.Query<Person>().AsDbSet();
+                dbSet.Add(people);
+
+                await dbSet.CommitChangesAsync();
+
+                people.Select(p => p.Id).Should().BeEquivalentTo(new int[] { 1, 2 });
+            }
+        }
+
+        [Fact]
+        public async Task DbSetShoulFillGeneratedIdsIntoEntitiesWhenTableIsNotEmpty()
+        {
+            using (var korm = CreateDatabase(CreateTable_People, InsertDataScript))
+            {
+                var people = new List<Person>() {
+                    new Person() { Name = "Milan" },
+                    new Person() { Name = "Peter" },
+                    new Person() { Name = "Juraj" }
+                };
+
+                IDbSet<Person> dbSet = korm.Query<Person>().AsDbSet();
+                dbSet.Add(people);
+
+                await dbSet.CommitChangesAsync();
+
+                people.Select(p => p.Id).Should().BeEquivalentTo(new int[] { 4, 5, 6 });
+            }
+        }
+
+        [Fact]
+        public async Task DbSetShoulFillGeneratedIdsIntoEntitiesWhenPrimaryKeyHasDifferentName()
+        {
+            using (var korm = CreateDatabase(CreateTable_People))
+            {
+                var data = new List<Foo>() {
+                    new Foo() { Value = "Bar 1" },
+                    new Foo() { Value = "Bar 2" }
+                };
+
+                IDbSet<Foo> dbSet = korm.Query<Foo>().AsDbSet();
+                dbSet.Add(data);
+
+                await dbSet.CommitChangesAsync();
+
+                data.Select(p => p.FooId).Should().BeEquivalentTo(new int[] { 1, 2 });
+            }
+        }
+    }
+}

--- a/tests/Kros.KORM.UnitTests/Integration/PrimaryKeyGenerationTests.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/PrimaryKeyGenerationTests.cs
@@ -33,7 +33,6 @@ namespace Kros.KORM.UnitTests.Integration
 
         #endregion
 
-
         #region SQL Scripts
 
         private static readonly string CreateTable_People =

--- a/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
@@ -395,6 +395,16 @@ namespace Kros.KORM.UnitTests
             }
 
             public bool SupportIdentity() => false;
+
+            public object ExecuteScalarCommand(IDbCommand command)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<object> ExecuteScalarCommandAsync(DbCommand command)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         #endregion

--- a/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
@@ -245,7 +245,7 @@ namespace Kros.KORM.UnitTests
                 new ColumnInfo(){
                     Name = "Id",
                     IsPrimaryKey = true,
-                    AutoIncrementMethodType = AutoIncrementMethodType.Indetity
+                    AutoIncrementMethodType = AutoIncrementMethodType.Identity
                 }
             }, new List<PropertyInfo>(), null);
 
@@ -260,8 +260,7 @@ namespace Kros.KORM.UnitTests
 
             action.Should()
                 .Throw<InvalidOperationException>()
-                .WithMessage("The provider 'FakeProvider' does not support inserting values " +
-                "into table which model 'Person' has set primary key as Identity.");
+                .WithMessage("*FakeProvider*Person*");
         }
 
         #endregion
@@ -394,7 +393,7 @@ namespace Kros.KORM.UnitTests
                 throw new NotImplementedException();
             }
 
-            public bool SupportIdentity() => false;
+            public bool SupportsIdentity() => false;
 
             public object ExecuteScalarCommand(IDbCommand command)
             {

--- a/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
@@ -256,7 +256,7 @@ namespace Kros.KORM.UnitTests
 
             dbSet.Add(new Person() { Name = "A" });
 
-            var action = new Action(() => dbSet.CommitChanges());
+            Action action = () => dbSet.CommitChanges();
 
             action.Should()
                 .Throw<InvalidOperationException>()

--- a/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorTestBase.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorTestBase.cs
@@ -296,7 +296,7 @@ namespace Kros.KORM.UnitTests.Query.Sql
                 throw new NotImplementedException();
             }
 
-            public bool SupportIdentity()
+            public bool SupportsIdentity()
             {
                 throw new NotImplementedException();
             }

--- a/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorTestBase.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorTestBase.cs
@@ -286,6 +286,11 @@ namespace Kros.KORM.UnitTests.Query.Sql
                 throw new NotImplementedException();
             }
 
+            public bool SupportIdentity()
+            {
+                throw new NotImplementedException();
+            }
+
             public bool SupportsPrepareCommand() => true;
         }
 

--- a/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorTestBase.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorTestBase.cs
@@ -266,6 +266,16 @@ namespace Kros.KORM.UnitTests.Query.Sql
                 throw new NotImplementedException();
             }
 
+            public object ExecuteScalarCommand(IDbCommand command)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<object> ExecuteScalarCommandAsync(DbCommand command)
+            {
+                throw new NotImplementedException();
+            }
+
             public TResult ExecuteStoredProcedure<TResult>(string storedProcedureName)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
This PR add support for autogenerated primary key with `MsSQL IDENTITY`.

Table must have sets primary key column as IDENTITY.
```sql
CREATE TABLE [dbo].[Users](
	[Id] [int] IDENTITY(1,1) NOT NULL,
	[FIrstName] [nvarchar](50) NULL,
 CONSTRAINT [PK_Users] PRIMARY KEY CLUSTERED
(
	[Id] ASC
)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
) ON [PRIMARY]
```
In entity class, you must mark property as `Key` with `AutoIncrementMethodType` set to `Identity`.
```c#
[Key(autoIncrementMethodType: AutoIncrementMethodType.Identity)]
public int Id { get; set; }
```

Next when you call `dbSet.CommitChanges()`, Kros.KORM fill generated keys into entity.
```c#
dbSet.Add(person);
dbSet.CommitChanges();

person.Id.Should().Be(1);
```

## Deficiencies
1. Identity is supported only for Ms Sql, no Ms Access.
2. BulkInset doesn't fill keys into entities

When you call `dbSet.BulkInsert()` Korm correctly insert data into table, but doesn't fill keys back to entities.
There is no direct way to do it.

There are two recommended ways:
1. Use option `SqlBulkCopyOptions.KeepIdentity` - keep identity from source
2. Use custom "hidden" uniqe column which values are known and after calling bulk insert, retrive keys using these values.

## What next
When nuget package with this change will be release, we need change `Kros.KORM.MsAccess` project. Implementing `SupportIdentity` into `QueryProvider`.

## Future improvements
KORM use reflection for getting data from entities and setting generated ids into entities. We can use DynamicMethods as in `DynamicMethodModelFactory`. This can improve performance. I will create new issue for this.