### PR TITLE
ExecuteNonQuery with params.

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,23 @@ using (var transaction = database.BeginTransaction())
 Kros.KORM supports SQL commands execution. There are three types of commands:
 
 * ```ExecuteNonQuery``` for commands that do not return value (DELETE, UPDATE, ...)
+
+  ```c#
+  private Database _database = new Database(new SqlConnection("connection string"));
+  
+  // to work with command parameters you can use CommandParameterCollection
+  var parameters = new CommandParameterCollection();
+  parameters.Add("@id", 10);
+  parameters.Add("@type", "DateTime");
+  
+  _database.ExecuteNonQuery("UPDATE Column = Value WHERE Id = @id AND Type = @type", parameters);
+  
+  // or you can send them directly via params array
+  _database.ExecuteNonQuery("UPDATE Column = Value WHERE Id = @id AND Type = @type", 10, "DateTime");
+  ```
+
 * ```ExecuteScalar``` for commands that return only one value (SELECT)
+
 * ```ExecuteStoredProcedure``` for executing of stored procedures. Stored procedure may return scalar value or list of values or it can return data in output parameters.
 
 #### Execution of stored procedure example

--- a/README.md
+++ b/README.md
@@ -499,13 +499,14 @@ Kros.KORM supports SQL commands execution. There are three types of commands:
   
   // to work with command parameters you can use CommandParameterCollection
   var parameters = new CommandParameterCollection();
+  parameters.Add("@value", "value");
   parameters.Add("@id", 10);
   parameters.Add("@type", "DateTime");
   
-  _database.ExecuteNonQuery("UPDATE Column = Value WHERE Id = @id AND Type = @type", parameters);
+  _database.ExecuteNonQuery("UPDATE Column = @value WHERE Id = @id AND Type = @type", parameters);
   
   // or you can send them directly via params array
-  _database.ExecuteNonQuery("UPDATE Column = Value WHERE Id = @id AND Type = @type", 10, "DateTime");
+  _database.ExecuteNonQuery("UPDATE Column = @value WHERE Id = @id AND Type = @type", "value", 10, "DateTime");
   ```
 
 * ```ExecuteScalar``` for commands that return only one value (SELECT)

--- a/src/Database.cs
+++ b/src/Database.cs
@@ -207,6 +207,10 @@ namespace Kros.KORM
         public async Task<int> ExecuteNonQueryAsync(string query) => await _queryProvider.ExecuteNonQueryAsync(query);
 
         /// <inheritdoc/>
+        public async Task<int> ExecuteNonQueryAsync(string query, params object[] parameters)
+            => await _queryProvider.ExecuteNonQueryAsync(query, parameters);
+
+        /// <inheritdoc/>
         public async Task<int> ExecuteNonQueryAsync(string query, CommandParameterCollection parameters)
             => await _queryProvider.ExecuteNonQueryAsync(query, parameters);
 

--- a/src/IDatabase.cs
+++ b/src/IDatabase.cs
@@ -98,6 +98,17 @@ namespace Kros.KORM
         Task<int> ExecuteNonQueryAsync(string query);
 
         /// <summary>
+        /// Asynchronously executes arbitrary query.
+        /// </summary>
+        /// <param name="query">Arbitrary SQL query. It should not be SELECT query.</param>
+        /// <param name="parameters">List of parameters.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation. The task result contains the
+        /// numbers of affected rows.
+        /// </returns>
+        Task<int> ExecuteNonQueryAsync(string query, params object[] parameters);
+
+        /// <summary>
         /// Asynchronously executes arbitrary query with parameters.
         /// </summary>
         /// <param name="query">Arbitrary SQL query. It should not be SELECT query.</param>

--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -251,6 +251,24 @@ namespace Kros.KORM.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot execute query. There are more parameters than values in the query..
+        /// </summary>
+        internal static string MoreParametersThanValues {
+            get {
+                return ResourceManager.GetString("MoreParametersThanValues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot execute query. There are more values than parameters in the query..
+        /// </summary>
+        internal static string MoreValuesThanParameters {
+            get {
+                return ResourceManager.GetString("MoreValuesThanParameters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Property NestedTransaction.CommandTimeout is readonly..
         /// </summary>
         internal static string NestedTransactionCommandTimeoutIsReadonly {

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -178,6 +178,12 @@
   <data name="MissongMethodInModelBuilder" xml:space="preserve">
     <value>ModelBuilder instance ({0}) does not have method {1}({2}).</value>
   </data>
+  <data name="MoreParametersThanValues" xml:space="preserve">
+    <value>Cannot execute query. There are more parameters than values in the query.</value>
+  </data>
+  <data name="MoreValuesThanParameters" xml:space="preserve">
+    <value>Cannot execute query. There are more values than parameters in the query.</value>
+  </data>
   <data name="NestedTransactionCommandTimeoutIsReadonly" xml:space="preserve">
     <value>Property NestedTransaction.CommandTimeout is readonly.</value>
   </data>

--- a/src/Query/Providers/IQueryProvider.cs
+++ b/src/Query/Providers/IQueryProvider.cs
@@ -165,6 +165,17 @@ namespace Kros.KORM.Query
         Task<int> ExecuteNonQueryAsync(string query);
 
         /// <summary>
+        /// Asynchronously executes arbitrary query.
+        /// </summary>
+        /// <param name="query">Arbitrary SQL query. It should not be SELECT query.</param>
+        /// <param name="parameters">List of query parameters.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation. The task result contains the
+        /// numbers of affected rows.
+        /// </returns>
+        Task<int> ExecuteNonQueryAsync(string query, params object[] parameters);
+
+        /// <summary>
         /// Asynchronously executes arbitrary query with parameters.
         /// </summary>
         /// <param name="query">Arbitrary SQL query. It should not be SELECT query.</param>

--- a/src/Query/Providers/IQueryProvider.cs
+++ b/src/Query/Providers/IQueryProvider.cs
@@ -173,6 +173,7 @@ namespace Kros.KORM.Query
         /// A task that represents the asynchronous operation. The task result contains the
         /// numbers of affected rows.
         /// </returns>
+        /// <exception cref="ArgumentException">Number of parameters does not match.</exception>
         Task<int> ExecuteNonQueryAsync(string query, params object[] paramValues);
 
         /// <summary>

--- a/src/Query/Providers/IQueryProvider.cs
+++ b/src/Query/Providers/IQueryProvider.cs
@@ -168,12 +168,12 @@ namespace Kros.KORM.Query
         /// Asynchronously executes arbitrary query.
         /// </summary>
         /// <param name="query">Arbitrary SQL query. It should not be SELECT query.</param>
-        /// <param name="parameters">List of query parameters.</param>
+        /// <param name="paramValues">List of query parameters.</param>
         /// <returns>
         /// A task that represents the asynchronous operation. The task result contains the
         /// numbers of affected rows.
         /// </returns>
-        Task<int> ExecuteNonQueryAsync(string query, params object[] parameters);
+        Task<int> ExecuteNonQueryAsync(string query, params object[] paramValues);
 
         /// <summary>
         /// Asynchronously executes arbitrary query with parameters.

--- a/src/Query/Providers/QueryProvider.cs
+++ b/src/Query/Providers/QueryProvider.cs
@@ -344,7 +344,23 @@ namespace Kros.KORM.Query
         }
 
         /// <inheritdoc/>
-        public async Task<int> ExecuteNonQueryAsync(string query) => await ExecuteNonQueryAsync(query, null);
+        public async Task<int> ExecuteNonQueryAsync(string query)
+            => await ExecuteNonQueryAsync(query, new CommandParameterCollection());
+
+        /// <inheritdoc/>
+        public Task<int> ExecuteNonQueryAsync(string query, params object[] parameters)
+        {
+            var paramsCollection = new CommandParameterCollection();
+            var tempParameters = new ParamEnumerator(query);
+
+            foreach (var parameter in parameters)
+            {
+                tempParameters.MoveNext();
+                paramsCollection.Add(tempParameters.Current, parameter);
+            }
+
+            return ExecuteNonQueryAsync(query, paramsCollection);
+        }
 
         /// <inheritdoc/>
         public async Task<int> ExecuteNonQueryAsync(string query, CommandParameterCollection parameters)

--- a/src/Query/Sql/ParamEnumerator.cs
+++ b/src/Query/Sql/ParamEnumerator.cs
@@ -7,7 +7,7 @@ namespace Kros.KORM.Query.Sql
 {
     internal class ParamEnumerator : IEnumerator<string>
     {
-        private string _sql;
+        private readonly string _sql;
         private string _current;
         private int _position = 0;
         private const string ParamPrefix = "@";
@@ -65,4 +65,3 @@ namespace Kros.KORM.Query.Sql
         }
     }
 }
-

--- a/src/Query/Sql/ParamEnumerator.cs
+++ b/src/Query/Sql/ParamEnumerator.cs
@@ -1,0 +1,68 @@
+﻿using Kros.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Kros.KORM.Query.Sql
+{
+    internal class ParamEnumerator : IEnumerator<string>
+    {
+        private string _sql;
+        private string _current;
+        private int _position = 0;
+        private const string ParamPrefix = "@";
+
+        public ParamEnumerator(string sql)
+        {
+            Check.NotNullOrWhiteSpace(sql, nameof(sql));
+            _sql = sql.Replace(Environment.NewLine, " ");
+            _sql = _sql.Replace("(", " ");
+            _sql = _sql.Replace(")", " ");
+        }
+
+        public string Current => _current;
+
+        public void Dispose()
+        {
+        }
+
+        object System.Collections.IEnumerator.Current => Current;
+
+        public bool MoveNext()
+        {
+            if (_position < _sql.Length)
+            {
+                var start = _sql.IndexOf(ParamPrefix, _position);
+                if (start > -1)
+                {
+                    var ends = new List<int>() {
+                            _sql.IndexOf(" ", start) ,
+                            _sql.IndexOf(",", start),
+                            _sql.IndexOf(")", start)}.Where(p => p > -1);
+
+                    var end = _sql.Length;
+
+                    if (ends.Any())
+                    {
+                        end = ends.Min();
+                    }
+
+                    _current = _sql.Substring(start, end - start).TrimStart().TrimEnd();
+                    _position = end;
+
+                    return true;
+                }
+
+                return false;
+            }
+
+            return false;
+        }
+
+        public void Reset()
+        {
+            _position = 0;
+        }
+    }
+}
+

--- a/src/Query/Sql/ParameterExtractingExpressionVisitor.cs
+++ b/src/Query/Sql/ParameterExtractingExpressionVisitor.cs
@@ -1,7 +1,6 @@
 ﻿using Kros.KORM.Query.Expressions;
 using Kros.Utils;
 using System;
-using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
@@ -79,66 +78,6 @@ namespace Kros.KORM.Query.Sql
                         _command.Parameters.Add(param);
                     }
                 }
-            }
-        }
-
-        private class ParamEnumerator : IEnumerator<string>
-        {
-            private string _sql;
-            private string _current;
-            private int _position = 0;
-            private const string ParamPrefix = "@";
-
-            public ParamEnumerator(string sql)
-            {
-                Check.NotNullOrWhiteSpace(sql, nameof(sql));
-                _sql = sql.Replace(Environment.NewLine, " ");
-                _sql = _sql.Replace("(", " ");
-                _sql = _sql.Replace(")", " ");
-            }
-
-            public string Current => _current;
-
-            public void Dispose()
-            {
-            }
-
-            object System.Collections.IEnumerator.Current => Current;
-
-            public bool MoveNext()
-            {
-                if (_position < _sql.Length)
-                {
-                    var start = _sql.IndexOf(ParamPrefix, _position);
-                    if (start > -1)
-                    {
-                        var ends = new List<int>() {
-                            _sql.IndexOf(" ", start) ,
-                            _sql.IndexOf(",", start),
-                            _sql.IndexOf(")", start)}.Where(p => p > -1);
-
-                        var end = _sql.Length;
-
-                        if (ends.Any())
-                        {
-                            end = ends.Min();
-                        }
-
-                        _current = _sql.Substring(start, end - start).TrimStart().TrimEnd();
-                        _position = end;
-
-                        return true;
-                    }
-
-                    return false;
-                }
-
-                return false;
-            }
-
-            public void Reset()
-            {
-                _position = 0;
             }
         }
     }

--- a/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
@@ -388,6 +388,11 @@ namespace Kros.KORM.UnitTests
                 throw new NotImplementedException();
             }
 
+            public Task<int> ExecuteNonQueryAsync(string query, params object[] parameters)
+            {
+                throw new NotImplementedException();
+            }
+
             public Task<int> ExecuteNonQueryAsync(string query, CommandParameterCollection parameters)
             {
                 throw new NotImplementedException();

--- a/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderShould.cs
@@ -276,6 +276,18 @@ END";
         }
 
         [Fact]
+        public async Task ExecuteNonQueryCommandParamsAsync()
+        {
+            using (SqlServerTestHelper helper = CreateHelper(CreateTable_TestTable))
+            {
+                var query = $"INSERT INTO {Table_TestTable} (Id, Number, Description) VALUES (@Id, @Number, @Description)";
+                QueryProvider provider = CreateQueryProvider(helper.Connection);
+                int result = await provider.ExecuteNonQueryAsync(query, 6, 666, "Sed ac lobortis magna.");
+                result.Should().Be(1); // Inserted 1 row.
+            }
+        }
+
+        [Fact]
         public async Task ExecuteNonQueryCommandAsync()
         {
             using (SqlServerTestHelper helper = CreateHelper(CreateTable_TestTable))

--- a/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorTestBase.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorTestBase.cs
@@ -246,6 +246,11 @@ namespace Kros.KORM.UnitTests.Query.Sql
                 throw new NotImplementedException();
             }
 
+            public Task<int> ExecuteNonQueryAsync(string query, params object[] parameters)
+            {
+                throw new NotImplementedException();
+            }
+
             public Task<int> ExecuteNonQueryAsync(string query, CommandParameterCollection parameters)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
Closes #5 

This PR adds support for executing query without the need to create CommandParameterCollection.

**Warning:** The list of values must have the same number and must be in the same order as the parameter list.

Example:

```c#
private Database _database = new Database(new SqlConnection("connection string"));

// to work with command parameters you can use CommandParameterCollection
var parameters = new CommandParameterCollection();
parameters.Add("@value", "value");
parameters.Add("@id", 10);
parameters.Add("@type", "DateTime");

_database.ExecuteNonQuery("UPDATE Column = @value WHERE Id = @id AND Type = @type", parameters);

// or you can send them directly via params array
_database.ExecuteNonQuery("UPDATE Column = @value WHERE Id = @id AND Type = @type", "value", 10, "DateTime");
```