### PR TITLE
Removed dependency on System.Configuration packages

### DIFF
--- a/src/Database.DatabaseBuilder.cs
+++ b/src/Database.DatabaseBuilder.cs
@@ -1,9 +1,8 @@
-using Kros.KORM.Materializer;
+﻿using Kros.KORM.Materializer;
 using Kros.KORM.Metadata;
 using Kros.KORM.Query;
 using Kros.Utils;
 using System;
-using System.Configuration;
 using System.Data.Common;
 
 namespace Kros.KORM
@@ -13,7 +12,7 @@ namespace Kros.KORM
         private class DatabaseBuilder : IDatabaseBuilder
         {
             private IQueryProviderFactory _queryProviderFactory;
-            private ConnectionStringSettings _connectionString;
+            private KormConnectionSettings _connectionString;
             private DbConnection _connection;
             private IModelFactory _modelFactory;
             private DatabaseConfigurationBase _databaseConfiguration;
@@ -46,7 +45,7 @@ namespace Kros.KORM
                 IQueryProviderFactory factory;
                 if (_connectionString != null)
                 {
-                    factory = _queryProviderFactory ?? QueryProviderFactories.GetFactory(_connectionString.ProviderName);
+                    factory = _queryProviderFactory ?? QueryProviderFactories.GetFactory(_connectionString.KormProvider);
                     return factory.Create(_connectionString, _modelBuilder.Value, _databaseMapper.Value);
                 }
                 else
@@ -69,7 +68,7 @@ namespace Kros.KORM
                 return modelMapper;
             }
 
-            public IDatabaseBuilder UseConnection(ConnectionStringSettings connectionString)
+            public IDatabaseBuilder UseConnection(KormConnectionSettings connectionString)
             {
                 CheckDuplicateSettingForConnection();
                 CheckMultipleConfiguration();
@@ -79,15 +78,13 @@ namespace Kros.KORM
                 return this;
             }
 
-            public IDatabaseBuilder UseConnection(string connectionString, string adoClientName)
+            public IDatabaseBuilder UseConnection(string connectionString)
             {
                 CheckDuplicateSettingForConnection();
                 CheckMultipleConfiguration();
+                Check.NotNullOrWhiteSpace(connectionString, nameof(connectionString));
 
-                _connectionString = new ConnectionStringSettings(
-                    "KORM",
-                    Check.NotNullOrWhiteSpace(connectionString, nameof(connectionString)),
-                    Check.NotNullOrWhiteSpace(adoClientName, nameof(adoClientName)));
+                _connectionString = KormConnectionSettings.Parse(connectionString);
 
                 return this;
             }

--- a/src/Database.DatabaseBuilder.cs
+++ b/src/Database.DatabaseBuilder.cs
@@ -84,7 +84,7 @@ namespace Kros.KORM
                 CheckMultipleConfiguration();
                 Check.NotNullOrWhiteSpace(connectionString, nameof(connectionString));
 
-                _connectionString = KormConnectionSettings.Parse(connectionString);
+                _connectionString = new KormConnectionSettings(connectionString);
 
                 return this;
             }

--- a/src/Database.cs
+++ b/src/Database.cs
@@ -6,7 +6,6 @@ using Kros.KORM.Query;
 using Kros.Utils;
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Data;
 using System.Data.Common;
 using System.Threading.Tasks;
@@ -90,9 +89,9 @@ namespace Kros.KORM
         /// <summary>
         /// Initializes a new instance of the <see cref="Database"/> class.
         /// </summary>
-        /// <param name="connectionString">The active connection.</param>
-        public Database(ConnectionStringSettings connectionString)
-            : this(connectionString, QueryProviderFactories.GetFactory(connectionString.ProviderName))
+        /// <param name="connectionString">Connection string settings.</param>
+        public Database(KormConnectionSettings connectionString)
+            : this(connectionString, QueryProviderFactories.GetFactory(connectionString.KormProvider))
         {
         }
 
@@ -100,9 +99,8 @@ namespace Kros.KORM
         /// Initializes a new instance of the <see cref="Database" /> class.
         /// </summary>
         /// <param name="connectionString">Connection string.</param>
-        /// <param name="adoClientName">Ado client name. (System.Data.SqlClient/System.Data.OleDb)</param>
-        public Database(string connectionString, string adoClientName)
-            : this(new ConnectionStringSettings("KORM", connectionString, adoClientName))
+        public Database(string connectionString)
+            : this(KormConnectionSettings.Parse(connectionString))
         {
         }
 
@@ -111,7 +109,7 @@ namespace Kros.KORM
         /// </summary>
         /// <param name="connectionString">The connection string settings.</param>
         /// <param name="queryProviderFactory">The query provider factory, which know create query provider.</param>
-        public Database(ConnectionStringSettings connectionString, IQueryProviderFactory queryProviderFactory)
+        public Database(KormConnectionSettings connectionString, IQueryProviderFactory queryProviderFactory)
         {
             Check.NotNull(connectionString, nameof(connectionString));
             Check.NotNull(queryProviderFactory, nameof(queryProviderFactory));

--- a/src/Database.cs
+++ b/src/Database.cs
@@ -100,7 +100,7 @@ namespace Kros.KORM
         /// </summary>
         /// <param name="connectionString">Connection string.</param>
         public Database(string connectionString)
-            : this(KormConnectionSettings.Parse(connectionString))
+            : this(new KormConnectionSettings(connectionString))
         {
         }
 

--- a/src/IDatabaseBuilder.cs
+++ b/src/IDatabaseBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using Kros.KORM.Materializer;
 using Kros.KORM.Query;
-using System.Configuration;
 using System.Data.Common;
 
 namespace Kros.KORM
@@ -15,15 +14,7 @@ namespace Kros.KORM
         /// </summary>
         /// <param name="connectionString">Connection string settings.</param>
         /// <returns>Database builder.</returns>
-        IDatabaseBuilder UseConnection(ConnectionStringSettings connectionString);
-
-        /// <summary>
-        /// Use <paramref name="connectionString"/> which instance of <see cref="IDatabase"/> will use for accessing to database.
-        /// </summary>
-        /// <param name="connectionString">Connection string settings.</param>
-        /// <param name="adoClientName">Ado client name. (System.Data.SqlClient/System.Data.OleDb)</param>
-        /// <returns>Database builder.</returns>
-        IDatabaseBuilder UseConnection(string connectionString, string adoClientName);
+        IDatabaseBuilder UseConnection(KormConnectionSettings connectionString);
 
         /// <summary>
         /// Use <paramref name="connection"/> which instance of <see cref="IDatabase"/> will use for accessing to database.

--- a/src/IDatabaseBuilderExtensions.cs
+++ b/src/IDatabaseBuilderExtensions.cs
@@ -12,6 +12,6 @@
         /// <param name="connectionString">Connection string.</param>
         /// <returns>Database builder.</returns>
         public static IDatabaseBuilder UseConnection(this IDatabaseBuilder builder, string connectionString)
-            => builder.UseConnection(KormConnectionSettings.Parse(connectionString));
+            => builder.UseConnection(new KormConnectionSettings(connectionString));
     }
 }

--- a/src/IDatabaseBuilderExtensions.cs
+++ b/src/IDatabaseBuilderExtensions.cs
@@ -1,0 +1,17 @@
+﻿namespace Kros.KORM
+{
+    /// <summary>
+    /// Extension methods for <see cref="IDatabaseBuilder"/>.
+    /// </summary>
+    public static class IDatabaseBuilderExtensions
+    {
+        /// <summary>
+        /// Use <paramref name="connectionString"/> which instance of <see cref="IDatabase"/> will use for accessing to database.
+        /// </summary>
+        /// <param name="builder">Databse builder.</param>
+        /// <param name="connectionString">Connection string.</param>
+        /// <returns>Database builder.</returns>
+        public static IDatabaseBuilder UseConnection(this IDatabaseBuilder builder, string connectionString)
+            => builder.UseConnection(KormConnectionSettings.Parse(connectionString));
+    }
+}

--- a/src/KormConnectionSettings.cs
+++ b/src/KormConnectionSettings.cs
@@ -64,13 +64,9 @@ namespace Kros.KORM
             {
                 ConnectionString = connectionString
             };
-            string kormProvider = GetKormProvider(cnstrBuilder);
-            bool autoMigrate = GetKormAutoMigrate(cnstrBuilder);
-            connectionString = cnstrBuilder.ConnectionString; // Previous methods remove keys, so we want clean connection string.
-
-            ConnectionString = connectionString;
-            KormProvider = kormProvider;
-            AutoMigrate = autoMigrate;
+            KormProvider = GetKormProvider(cnstrBuilder);
+            AutoMigrate = GetKormAutoMigrate(cnstrBuilder);
+            ConnectionString = cnstrBuilder.ConnectionString; // Previous methods remove keys, so we want clean connection string.
         }
 
         /// <summary>

--- a/src/KormConnectionSettings.cs
+++ b/src/KormConnectionSettings.cs
@@ -1,0 +1,99 @@
+﻿using Kros.Utils;
+using System.Data.Common;
+
+namespace Kros.KORM
+{
+    /// <summary>
+    /// Settings for KORM database.
+    /// </summary>
+    public class KormConnectionSettings
+    {
+        private const string DefaultProviderName = Kros.Data.SqlServer.SqlServerDataHelper.ClientId;
+        private const bool DefaultAutoMigrate = false;
+
+        /// <summary>
+        /// Key for connection string for setting KORM database provider. If the provider is not set in connection string,
+        /// Microsoft SQL Server provider is used.
+        /// </summary>
+        public const string KormProviderKey = "KormProvider";
+
+        /// <summary>
+        /// Key for connection string for setting if automatic migrations are enabled.
+        /// If the value is not set in connection string, automatic migrations are disabled.
+        /// </summary>
+        public const string KormAutoMigrateKey = "KormAutoMigrate";
+
+        /// <summary>
+        /// Parses input <paramref name="connectionString"/> string. Values of KORM keys are removed from connection string
+        /// and set to appropriate properties. Missing KORM keys are set to default values.
+        /// </summary>
+        /// <param name="connectionString">Input connection string.</param>
+        /// <returns>Initialized <see cref="KormConnectionSettings"/> instance.</returns>
+        public static KormConnectionSettings Parse(string connectionString)
+        {
+            Check.NotNullOrWhiteSpace(connectionString, nameof(connectionString));
+
+            var cnstrBuilder = new DbConnectionStringBuilder
+            {
+                ConnectionString = connectionString
+            };
+            string kormProvider = GetKormProvider(cnstrBuilder);
+            bool autoMigrate = GetKormAutoMigrate(cnstrBuilder);
+            connectionString = cnstrBuilder.ConnectionString; // Previous methods remove keys, so we want clean connection string.
+
+            return new KormConnectionSettings(connectionString, kormProvider, autoMigrate);
+        }
+
+        private static string GetKormProvider(DbConnectionStringBuilder cnstrBuilder)
+        {
+            if (cnstrBuilder.TryGetValue(KormProviderKey, out object cnstrProviderName))
+            {
+                cnstrBuilder.Remove(KormProviderKey);
+                string providerName = (string)cnstrProviderName;
+                if (!string.IsNullOrWhiteSpace(providerName))
+                {
+                    return providerName;
+                }
+            }
+            return DefaultProviderName;
+        }
+
+        private static bool GetKormAutoMigrate(DbConnectionStringBuilder cnstrBuilder)
+        {
+            if (cnstrBuilder.TryGetValue(KormAutoMigrateKey, out object cnstrAutoMigrate))
+            {
+                cnstrBuilder.Remove(KormAutoMigrateKey);
+                if (bool.TryParse((string)cnstrAutoMigrate, out bool autoMigrate))
+                {
+                    return autoMigrate;
+                }
+            }
+            return DefaultAutoMigrate;
+        }
+
+        private KormConnectionSettings(string connectionString, string kormProvider, bool autoMigrate)
+        {
+            ConnectionString = connectionString;
+            KormProvider = kormProvider;
+            AutoMigrate = autoMigrate;
+        }
+
+        /// <summary>
+        /// Connection string for database. This connection string is the same as input connection string,
+        /// just without KORM keys.
+        /// </summary>
+        public string ConnectionString { get; }
+
+        /// <summary>
+        /// KORM provider, parsed from input connection: <c>KormProvider</c> key.
+        /// If the key is not present in the connection string, default value for Microsoft SQL Server will be used.
+        /// </summary>
+        public string KormProvider { get; }
+
+        /// <summary>
+        /// Automatic migration value parsed from input connection: <c>KormAutoMigrate</c> key.
+        /// If the key was not present in the connection string, default value <see langword="false"/> will be used.
+        /// </summary>
+        public bool AutoMigrate { get; }
+    }
+}

--- a/src/KormConnectionSettings.cs
+++ b/src/KormConnectionSettings.cs
@@ -23,27 +23,6 @@ namespace Kros.KORM
         /// </summary>
         public const string KormAutoMigrateKey = "KormAutoMigrate";
 
-        /// <summary>
-        /// Parses input <paramref name="connectionString"/> string. Values of KORM keys are removed from connection string
-        /// and set to appropriate properties. Missing KORM keys are set to default values.
-        /// </summary>
-        /// <param name="connectionString">Input connection string.</param>
-        /// <returns>Initialized <see cref="KormConnectionSettings"/> instance.</returns>
-        public static KormConnectionSettings Parse(string connectionString)
-        {
-            Check.NotNullOrWhiteSpace(connectionString, nameof(connectionString));
-
-            var cnstrBuilder = new DbConnectionStringBuilder
-            {
-                ConnectionString = connectionString
-            };
-            string kormProvider = GetKormProvider(cnstrBuilder);
-            bool autoMigrate = GetKormAutoMigrate(cnstrBuilder);
-            connectionString = cnstrBuilder.ConnectionString; // Previous methods remove keys, so we want clean connection string.
-
-            return new KormConnectionSettings(connectionString, kormProvider, autoMigrate);
-        }
-
         private static string GetKormProvider(DbConnectionStringBuilder cnstrBuilder)
         {
             if (cnstrBuilder.TryGetValue(KormProviderKey, out object cnstrProviderName))
@@ -71,8 +50,24 @@ namespace Kros.KORM
             return DefaultAutoMigrate;
         }
 
-        private KormConnectionSettings(string connectionString, string kormProvider, bool autoMigrate)
+        /// <summary>
+        /// Parses input <paramref name="connectionString"/> string. Values of KORM keys are removed from connection string
+        /// and set to appropriate properties. Missing KORM keys are set to default values. If KORM provider is not set
+        /// in connection string, Microsoft SQL Server will be used.
+        /// </summary>
+        /// <param name="connectionString">Input connection string.</param>
+        public KormConnectionSettings(string connectionString)
         {
+            Check.NotNullOrWhiteSpace(connectionString, nameof(connectionString));
+
+            var cnstrBuilder = new DbConnectionStringBuilder
+            {
+                ConnectionString = connectionString
+            };
+            string kormProvider = GetKormProvider(cnstrBuilder);
+            bool autoMigrate = GetKormAutoMigrate(cnstrBuilder);
+            connectionString = cnstrBuilder.ConnectionString; // Previous methods remove keys, so we want clean connection string.
+
             ConnectionString = connectionString;
             KormProvider = kormProvider;
             AutoMigrate = autoMigrate;

--- a/src/Kros.KORM.csproj
+++ b/src/Kros.KORM.csproj
@@ -30,9 +30,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System.Configuration" />
-  </ItemGroup>
   <ItemGroup>
     <None Remove="Resources\MigrationsHistoryTableScript.sql" />
   </ItemGroup>
@@ -43,16 +40,6 @@
     <PackageReference Include="Kros.Utils" Version="1.9.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Configuration.ConfigurationManager">
-      <Version>4.4.1</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="System.Configuration.ConfigurationManager">
-      <Version>4.5.0</Version>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/src/Query/Providers/IQueryProviderFactory.cs
+++ b/src/Query/Providers/IQueryProviderFactory.cs
@@ -1,11 +1,6 @@
 ﻿using Kros.KORM.Materializer;
-using System;
-using System.Collections.Generic;
-using System.Data.Common;
-using System.Linq;
-using System.Text;
-using System.Configuration;
 using Kros.KORM.Metadata;
+using System.Data.Common;
 
 namespace Kros.KORM.Query
 {
@@ -34,6 +29,6 @@ namespace Kros.KORM.Query
         /// <returns>
         ///  Instance of IQueryProvider.
         /// </returns>
-        IQueryProvider Create(ConnectionStringSettings connectionString, IModelBuilder modelBuilder, IDatabaseMapper databaseMapper);
+        IQueryProvider Create(KormConnectionSettings connectionString, IModelBuilder modelBuilder, IDatabaseMapper databaseMapper);
     }
 }

--- a/src/Query/Providers/QueryProvider.cs
+++ b/src/Query/Providers/QueryProvider.cs
@@ -12,7 +12,6 @@ using Kros.Utils;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
@@ -100,7 +99,7 @@ namespace Kros.KORM.Query
         private readonly ILogger _logger;
         private readonly ISqlExpressionVisitorFactory _sqlGeneratorFactory;
         private readonly IModelBuilder _modelBuilder;
-        private readonly ConnectionStringSettings _connectionSettings = null;
+        private readonly KormConnectionSettings _connectionSettings = null;
         private DbConnection _connection = null;
         private readonly Cache<string, TableSchema> _tableSchemas =
             new Cache<string, TableSchema>(StringComparer.OrdinalIgnoreCase);
@@ -119,7 +118,7 @@ namespace Kros.KORM.Query
         /// <param name="modelBuilder">The model builder.</param>
         /// <param name="logger">The logger.</param>
         public QueryProvider(
-            ConnectionStringSettings connectionSettings,
+            KormConnectionSettings connectionSettings,
             ISqlExpressionVisitorFactory sqlGeneratorFactory,
             IModelBuilder modelBuilder,
             ILogger logger)
@@ -602,7 +601,7 @@ namespace Kros.KORM.Query
 
         /// <summary>
         /// Connection string na databázu, ktorý bol zadaný pri vytvorení inštancie triedy
-        /// (<see cref="QueryProvider.QueryProvider(ConnectionStringSettings, ISqlExpressionVisitorFactory, IModelBuilder, ILogger)"/>).
+        /// (<see cref="QueryProvider(KormConnectionSettings, ISqlExpressionVisitorFactory, IModelBuilder, ILogger)"/>).
         /// Ak bola trieda vytvorená konkrétnou inštanciou spojenia, vráti <see langword="null"/>.
         /// </summary>
         protected string ConnectionString { get => _connectionSettings?.ConnectionString; }
@@ -620,8 +619,7 @@ namespace Kros.KORM.Query
         /// </summary>
         protected DbConnection Connection
         {
-            get
-            {
+            get {
                 if (_connection == null)
                 {
                     _connection = DbProviderFactory.CreateConnection();

--- a/src/Query/Providers/SqlServerQueryProvider.cs
+++ b/src/Query/Providers/SqlServerQueryProvider.cs
@@ -5,7 +5,6 @@ using Kros.Data.Schema.SqlServer;
 using Kros.KORM.Helper;
 using Kros.KORM.Materializer;
 using Kros.KORM.Query.Sql;
-using System.Configuration;
 using System.Data.Common;
 using System.Data.SqlClient;
 
@@ -25,7 +24,7 @@ namespace Kros.KORM.Query
         /// <param name="modelBuilder">The model builder.</param>
         /// <param name="logger">The logger.</param>
         public SqlServerQueryProvider(
-            ConnectionStringSettings connectionString,
+            KormConnectionSettings connectionString,
             ISqlExpressionVisitorFactory sqlGeneratorFactory,
             IModelBuilder modelBuilder,
             ILogger logger)

--- a/src/Query/Providers/SqlServerQueryProviderFactory.cs
+++ b/src/Query/Providers/SqlServerQueryProviderFactory.cs
@@ -3,7 +3,6 @@ using Kros.KORM.Helper;
 using Kros.KORM.Materializer;
 using Kros.KORM.Metadata;
 using Kros.KORM.Query.Providers;
-using System.Configuration;
 using System.Data.Common;
 using System.Data.SqlClient;
 
@@ -37,7 +36,7 @@ namespace Kros.KORM.Query
         /// Instance of <see cref="SqlServerQueryProvider"/>.
         /// </returns>
         public IQueryProvider Create(
-            ConnectionStringSettings connectionString,
+            KormConnectionSettings connectionString,
             IModelBuilder modelBuilder,
             IDatabaseMapper databaseMapper)
             => new SqlServerQueryProvider(

--- a/tests/Kros.KORM.UnitTests/Helpers.cs
+++ b/tests/Kros.KORM.UnitTests/Helpers.cs
@@ -2,7 +2,7 @@
 
 namespace Kros.KORM.UnitTests
 {
-    internal class ConfigurationHelper
+    internal static class Helpers
     {
         private static IConfigurationRoot _config;
 
@@ -18,5 +18,8 @@ namespace Kros.KORM.UnitTests
 
             return _config;
         }
+
+        public static string AddProviderToConnectionString(string connectionString, string kormProvider)
+            => $"{connectionString};{KormConnectionSettings.KormProviderKey}={kormProvider}";
     }
 }

--- a/tests/Kros.KORM.UnitTests/Integration/IntegrationTestConfig.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/IntegrationTestConfig.cs
@@ -3,6 +3,6 @@
     internal static class IntegrationTestConfig
     {
         internal static string ConnectionString
-            => ConfigurationHelper.GetConfiguration().GetSection("connectionString").Value;
+            => Helpers.GetConfiguration().GetSection("ConnectionStrings:DefaultConnection").Value;
     }
 }

--- a/tests/Kros.KORM.UnitTests/Integration/TransactionTests.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/TransactionTests.cs
@@ -356,7 +356,7 @@ $@" CREATE PROCEDURE [dbo].[WaitForTwoSeconds] AS
 
         private void ExplicitTransactionCommit(TestDatabase database)
         {
-            using (var korm = new Database(database.ConnectionString, SqlServerDataHelper.ClientId))
+            using (var korm = new Database(database.ConnectionString))
             using (var transaction = korm.BeginTransaction())
             {
                 var dbSet = korm.Query<Invoice>().AsDbSet();
@@ -380,7 +380,7 @@ $@" CREATE PROCEDURE [dbo].[WaitForTwoSeconds] AS
 
         private void ExplicitTransactionRollback(TestDatabase database)
         {
-            using (var korm = new Database(database.ConnectionString, SqlServerDataHelper.ClientId))
+            using (var korm = new Database(database.ConnectionString))
             using (var transaction = korm.BeginTransaction())
             {
                 var dbSet = korm.Query<Invoice>().AsDbSet();
@@ -405,7 +405,7 @@ $@" CREATE PROCEDURE [dbo].[WaitForTwoSeconds] AS
 
         private void ExplicitTransactionRollbackAfterBulkInsert(TestDatabase database)
         {
-            using (var korm = new Database(database.ConnectionString, SqlServerDataHelper.ClientId))
+            using (var korm = new Database(database.ConnectionString))
             using (var transaction = korm.BeginTransaction())
             {
                 var dbSet = korm.Query<Invoice>().AsDbSet();
@@ -430,7 +430,7 @@ $@" CREATE PROCEDURE [dbo].[WaitForTwoSeconds] AS
 
         private void ExplicitTransactionCommitAfterBulkInsert(TestDatabase database)
         {
-            using (var korm = new Database(database.ConnectionString, SqlServerDataHelper.ClientId))
+            using (var korm = new Database(database.ConnectionString))
             using (var transaction = korm.BeginTransaction())
             {
                 var dbSet = korm.Query<Invoice>().AsDbSet();
@@ -448,7 +448,7 @@ $@" CREATE PROCEDURE [dbo].[WaitForTwoSeconds] AS
         public void ExplicitTransactionShould_ThrowCommandTimeoutExceptionWhenIsSetTooSmall()
         {
             using (var database = CreateAndInitDatabase(CreateProcedure_WaitForTwoSeconds))
-            using (var korm = new Database(database.ConnectionString, SqlServerDataHelper.ClientId))
+            using (var korm = new Database(database.ConnectionString))
             using (var transaction = korm.BeginTransaction())
             {
                 transaction.CommandTimeout = 1;
@@ -464,7 +464,7 @@ $@" CREATE PROCEDURE [dbo].[WaitForTwoSeconds] AS
         public void ExplicitTransactionShould_ThrowInvalidOperationExceptionWhenCommandTimeoutSetForNestedTransaction()
         {
             using (var database = CreateAndInitDatabase(CreateProcedure_WaitForTwoSeconds))
-            using (var korm = new Database(database.ConnectionString, SqlServerDataHelper.ClientId))
+            using (var korm = new Database(database.ConnectionString))
             using (var mainTransaction = korm.BeginTransaction())
             {
                 using (var nestedTransaction = korm.BeginTransaction())
@@ -481,7 +481,7 @@ $@" CREATE PROCEDURE [dbo].[WaitForTwoSeconds] AS
         public void ExplicitTransactionShould_NotThrowCommandTimeoutExceptionWhenIsSetSufficient()
         {
             using (var database = CreateAndInitDatabase(CreateProcedure_WaitForTwoSeconds))
-            using (var korm = new Database(database.ConnectionString, SqlServerDataHelper.ClientId))
+            using (var korm = new Database(database.ConnectionString))
             using (var transaction = korm.BeginTransaction())
             {
                 transaction.CommandTimeout = 3;
@@ -520,7 +520,7 @@ $@" CREATE PROCEDURE [dbo].[WaitForTwoSeconds] AS
 
         private void DatabaseShouldContainInvoices(string connectionString, IEnumerable<Invoice> expected)
         {
-            using (var korm = new Database(connectionString, SqlServerDataHelper.ClientId))
+            using (var korm = new Database(connectionString))
             {
                 DatabaseShouldContainInvoices(korm, expected);
             }

--- a/tests/Kros.KORM.UnitTests/Integration/TransactionTests_BulkUpdate.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/TransactionTests_BulkUpdate.cs
@@ -1,5 +1,4 @@
 ﻿using FluentAssertions;
-using Kros.Data.SqlServer;
 using Kros.KORM.Query;
 using Kros.KORM.UnitTests.Base;
 using System;
@@ -213,7 +212,7 @@ namespace Kros.KORM.UnitTests.Integration
             Action<IDbConnection, IDbTransaction, string> action,
             Action<IDbSet<Invoice>, Action<IDbConnection, IDbTransaction, string>> dbSetAction)
         {
-            using (var korm = new Database(database.ConnectionString, SqlServerDataHelper.ClientId))
+            using (var korm = new Database(database.ConnectionString))
             using (var transaction = korm.BeginTransaction())
             {
                 var dbSet = korm.Query<Invoice>().AsDbSet();
@@ -265,7 +264,7 @@ namespace Kros.KORM.UnitTests.Integration
             Action<IDbSet<Invoice>, Action<IDbConnection, IDbTransaction, string>> dbSetAction,
             TestDatabase database)
         {
-            using (var korm = new Database(database.ConnectionString, SqlServerDataHelper.ClientId))
+            using (var korm = new Database(database.ConnectionString))
             using (var transaction = korm.BeginTransaction())
             {
                 var dbSet = korm.Query<Invoice>().AsDbSet();

--- a/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderFactoriesShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderFactoriesShould.cs
@@ -8,7 +8,6 @@ using Kros.KORM.Query;
 using Kros.KORM.Query.Providers;
 using Kros.KORM.Query.Sql;
 using System;
-using System.Configuration;
 using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
@@ -62,7 +61,8 @@ namespace Kros.KORM.UnitTests.Query.Providers
 
         public class CustomQueryProvider : QueryProvider
         {
-            public CustomQueryProvider(ConnectionStringSettings connectionString,
+            public CustomQueryProvider(
+                KormConnectionSettings connectionString,
                 ISqlExpressionVisitorFactory sqlGeneratorFactory,
                 IModelBuilder modelBuilder,
                 ILogger logger)
@@ -101,7 +101,7 @@ namespace Kros.KORM.UnitTests.Query.Providers
                     connection, new SqlServerSqlExpressionVisitorFactory(databaseMapper), modelBuilder, new Logger());
 
             public IQueryProvider Create(
-                ConnectionStringSettings connectionString,
+                KormConnectionSettings connectionString,
                 IModelBuilder modelBuilder,
                 IDatabaseMapper databaseMapper)
                 => new CustomQueryProvider(

--- a/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderFactoryShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderFactoryShould.cs
@@ -36,7 +36,7 @@ namespace Kros.KORM.UnitTests.Query
         public void CreateOleDbProviderBySettings()
         {
             var factory = CreateFactory();
-            var connectionString = KormConnectionSettings.Parse(Helpers.AddProviderToConnectionString("", "System.Data.OleDb"));
+            var connectionString = new KormConnectionSettings(Helpers.AddProviderToConnectionString("", "System.Data.OleDb"));
             var provider = factory.Create(connectionString, CreateModelBuilder(), DatabaseMapper);
 
             provider.Should().NotBeNull();
@@ -46,7 +46,7 @@ namespace Kros.KORM.UnitTests.Query
         public void CreateSqlProviderBySettings()
         {
             var factory = CreateFactory();
-            var connectionString = KormConnectionSettings.Parse(Helpers.AddProviderToConnectionString("", SqlServerDataHelper.ClientId));
+            var connectionString = new KormConnectionSettings(Helpers.AddProviderToConnectionString("", SqlServerDataHelper.ClientId));
 
             var provider = factory.Create(connectionString, CreateModelBuilder(), DatabaseMapper);
 
@@ -57,7 +57,7 @@ namespace Kros.KORM.UnitTests.Query
         public void CreateSqlProviderBySettingsCaseInsensitive()
         {
             var factory = CreateFactory();
-            var connectionString = KormConnectionSettings.Parse(Helpers.AddProviderToConnectionString("", SqlServerDataHelper.ClientId));
+            var connectionString = new KormConnectionSettings(Helpers.AddProviderToConnectionString("", SqlServerDataHelper.ClientId));
 
             var provider = factory.Create(connectionString, CreateModelBuilder(), DatabaseMapper);
 

--- a/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderFactoryShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderFactoryShould.cs
@@ -3,7 +3,6 @@ using Kros.Data.SqlServer;
 using Kros.KORM.Materializer;
 using Kros.KORM.Metadata;
 using Kros.KORM.Query;
-using System.Configuration;
 using System.Data.SqlClient;
 using Xunit;
 
@@ -37,7 +36,7 @@ namespace Kros.KORM.UnitTests.Query
         public void CreateOleDbProviderBySettings()
         {
             var factory = CreateFactory();
-            var connectionString = new ConnectionStringSettings("Default", "", "System.Data.OleDb");
+            var connectionString = KormConnectionSettings.Parse(Helpers.AddProviderToConnectionString("", "System.Data.OleDb"));
             var provider = factory.Create(connectionString, CreateModelBuilder(), DatabaseMapper);
 
             provider.Should().NotBeNull();
@@ -47,7 +46,7 @@ namespace Kros.KORM.UnitTests.Query
         public void CreateSqlProviderBySettings()
         {
             var factory = CreateFactory();
-            var connectionString = new ConnectionStringSettings("Default", "", SqlServerDataHelper.ClientId);
+            var connectionString = KormConnectionSettings.Parse(Helpers.AddProviderToConnectionString("", SqlServerDataHelper.ClientId));
 
             var provider = factory.Create(connectionString, CreateModelBuilder(), DatabaseMapper);
 
@@ -58,7 +57,7 @@ namespace Kros.KORM.UnitTests.Query
         public void CreateSqlProviderBySettingsCaseInsensitive()
         {
             var factory = CreateFactory();
-            var connectionString = new ConnectionStringSettings("Default", "", SqlServerDataHelper.ClientId);
+            var connectionString = KormConnectionSettings.Parse(Helpers.AddProviderToConnectionString("", SqlServerDataHelper.ClientId));
 
             var provider = factory.Create(connectionString, CreateModelBuilder(), DatabaseMapper);
 

--- a/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderShould.cs
@@ -1,7 +1,6 @@
 ﻿using FluentAssertions;
 using Kros.Data.BulkActions;
 using Kros.Data.Schema;
-using Kros.Data.SqlServer;
 using Kros.KORM.Helper;
 using Kros.KORM.Materializer;
 using Kros.KORM.Query;
@@ -11,7 +10,6 @@ using Kros.UnitTests;
 using NSubstitute;
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
@@ -54,7 +52,7 @@ namespace Kros.KORM.UnitTests.Query.Providers
 
             private TestQueryProvider(DbConnection internalConnection, bool isInternalConnection)
                 : base(
-                      new ConnectionStringSettings("QueryProviderTest", "QueryProviderTestConnectionString", "QueryProviderTest"),
+                      KormConnectionSettings.Parse(Helpers.AddProviderToConnectionString("QueryProviderTestConnectionString", "QueryProviderTest")),
                       Substitute.For<ISqlExpressionVisitorFactory>(),
                       new ModelBuilder(Database.DefaultModelFactory),
                       Substitute.For<ILogger>())
@@ -511,7 +509,7 @@ END";
 
         private static SqlServerQueryProvider CreateQueryProvider(string connectionString)
             => new SqlServerQueryProvider(
-                new ConnectionStringSettings("Default", connectionString, SqlServerDataHelper.ClientId),
+                KormConnectionSettings.Parse(connectionString),
                 Substitute.For<ISqlExpressionVisitorFactory>(),
                 new ModelBuilder(Database.DefaultModelFactory),
                 Substitute.For<ILogger>());

--- a/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderShould.cs
@@ -52,7 +52,7 @@ namespace Kros.KORM.UnitTests.Query.Providers
 
             private TestQueryProvider(DbConnection internalConnection, bool isInternalConnection)
                 : base(
-                      KormConnectionSettings.Parse(Helpers.AddProviderToConnectionString("QueryProviderTestConnectionString", "QueryProviderTest")),
+                      new KormConnectionSettings(Helpers.AddProviderToConnectionString("QueryProviderTestConnectionString", "QueryProviderTest")),
                       Substitute.For<ISqlExpressionVisitorFactory>(),
                       new ModelBuilder(Database.DefaultModelFactory),
                       Substitute.For<ILogger>())
@@ -509,7 +509,7 @@ END";
 
         private static SqlServerQueryProvider CreateQueryProvider(string connectionString)
             => new SqlServerQueryProvider(
-                KormConnectionSettings.Parse(connectionString),
+                new KormConnectionSettings(connectionString),
                 Substitute.For<ISqlExpressionVisitorFactory>(),
                 new ModelBuilder(Database.DefaultModelFactory),
                 Substitute.For<ILogger>());

--- a/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorTestBase.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorTestBase.cs
@@ -11,7 +11,6 @@ using Kros.KORM.Query.Providers;
 using Kros.KORM.Query.Sql;
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
@@ -314,7 +313,7 @@ namespace Kros.KORM.UnitTests.Query.Sql
             public KORM.Query.IQueryProvider Create(DbConnection connection, IModelBuilder modelBuilder, IDatabaseMapper databaseMapper)
                 => new FakeQueryProvider();
 
-            public KORM.Query.IQueryProvider Create(ConnectionStringSettings connectionString, IModelBuilder modelBuilder, IDatabaseMapper databaseMapper)
+            public KORM.Query.IQueryProvider Create(KormConnectionSettings connectionString, IModelBuilder modelBuilder, IDatabaseMapper databaseMapper)
             {
                 throw new NotImplementedException();
             }

--- a/tests/Kros.KORM.UnitTests/appsettings.json
+++ b/tests/Kros.KORM.UnitTests/appsettings.json
@@ -1,3 +1,5 @@
 {
-  "connectionString": "Server=(local)\\SQL2016; UID=sa;PWD=Password12!; Persist Security Info = 'TRUE'"
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(local)\\SQL2016; UID=sa; PWD=Password12!; Persist Security Info=true"
+  }
 }


### PR DESCRIPTION
Removed dependencies for packages:
- System.Configuration
- System.Configuration.ConfigurationManager

These packages were there only because of `ConnectionStringSettings` class. I created new class `KormConnectionSettings` and the preferred way of the settings is to use simple connection string with special KORM keys.

It is a breaking change for clients using KORM.