### PR TITLE
WIP Delete by id and condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can use Kros.KORM for creating queries and their materialization. Kros.KORM 
 
 #### Query for obtaining data
 
-```c#
+```CSharp
 var people = database.Query<Person>()
     .Select("p.Id", "FirstName", "LastName", "PostCode")
     .From("Person JOIN Address ON (Person.AddressId = Address.Id)")
@@ -69,7 +69,7 @@ Kros.KORM allows you to use Linq for creating queries. Basic queries are transla
 
 #### Example
 
-```c#
+```CSharp
 var people = database.Query<Person>()
     .From("Person JOIN Address ON (Person.AddressId = Address.Id)")
     .Where(p => p.LastName.EndsWith("ová"))
@@ -106,7 +106,7 @@ Translation is provided by implementation of [ISqlExpressionVisitor](https://kro
 
 Properties (not readonly or writeonly properties) are implicitly mapped to database fields with same name. When you want to map property to database field with different name use AliasAttribute. The same works for mapping POCO classes with database tables.
 
-```c#
+```CSharp
 [Alias("Workers")]
 private class Staff
 {
@@ -136,7 +136,7 @@ private void StaffExample()
 
 When you need to have read-write properties independent of the database use `NoMapAttribute`.
 
-```c#
+```CSharp
 [NoMap]
 public int Computed { get; set; }
 ```
@@ -147,7 +147,7 @@ If you have different conventions for naming properties in POCO classes and fiel
 
 #### Redefining mapping conventions example
 
-```c#
+```CSharp
 Database.DefaultModelMapper.MapColumnName = (colInfo, modelType) =>
 {
     return string.Format("COL_{0}", colInfo.PropertyInfo.Name.ToUpper());
@@ -179,7 +179,7 @@ Alternatively you can write your own implementation of [IModelMapper](https://kr
 
 ##### Custom model mapper
 
-```c#
+```CSharp
 Database.DefaultModelMapper = new CustomModelMapper();
 ```
 
@@ -187,7 +187,7 @@ If your POCO class is defined in external library, you can redefine mapper, so i
 
 ##### External class mapping example
 
-```c#
+```CSharp
 var externalPersonMap = new Dictionary<string, string>() {
     { nameOf(ExternalPerson.oId), "Id" },
     { nameOf(ExternalPerson.Name), "FirstName" },
@@ -219,7 +219,7 @@ using (var database = new Database(_connection))
 
 For dynamic mapping you can use method [SetColumnName<TModel, TValue>](https://kros-sk.github.io/Kros.Libs.Documentation/api/Kros.KORM.Metadata.IModelMapper.html#Kros_KORM_Metadata_IModelMapper_SetColumnName__2_System_Linq_Expressions_Expression_System_Func___0___1___System_String_)
 
-```c#
+```CSharp
 Database.DefaultModelMapper.SetColumnName<Person, string>(p => p.Name, "FirstName");
 ```
 
@@ -231,7 +231,7 @@ For example, if you want to have entities in domain layer and mapping in infrast
 
 For these scenarios you can derive database configuration from `DatabaseConfigurationBase`.
 
-```c#
+```CSharp
 public class User
 {
     public int Id { get; set; }
@@ -262,7 +262,7 @@ public class DatabaseConfiguration : DatabaseConfigurationBase
 
 And use `IDatabaseBuilder` for creating KORM instance.
 
-```c#
+```CSharp
 var database = Database
     .Builder
     .UseConnection(connection)
@@ -283,7 +283,7 @@ Imagine you store a list of addresses separated by some special character (for e
 
 Let's define a converter that can convert string to list of strings.
 
-```c#
+```CSharp
 public class AddressesConverter : IConverter
 {
     public object Convert(object value)
@@ -309,7 +309,7 @@ public class AddressesConverter : IConverter
 
 And now you can set this converter for your property using attribute or [fluent configuration](#Configure-model-mapping-by-fluent-api).
 
-```c#
+```CSharp
 [Converter(typeof(AddressesConverter))]
 public List<string> Addresses { get; set; }
 ```
@@ -322,7 +322,7 @@ You can do whatever you need in method ```OnAfterMaterialize```.
 
 For example, if you have three int columns for date in database (Year, Month and Day) but in your POCO class you have only one date property, you can solve it as follows:
 
-```c#
+```CSharp
 [NoMap]
 public DateTime Date { get; set; }
 
@@ -342,7 +342,7 @@ Sometimes you might need to inject some service to your model, for example calcu
 
 Let's have properties in model
 
-```c#
+```CSharp
 [NoMap]
 public ICalculationService CalculationService { get; set; }
 
@@ -352,7 +352,7 @@ public ILogger Logger { get; set; }
 
 And that is how you can configure them.
 
-```c#
+```CSharp
 Database.DefaultModelMapper
     .InjectionConfigurator<Person>()
         .FillProperty(p => p.CalculationService, () => new CalculationService())
@@ -367,7 +367,7 @@ By default `DynamicMethodModelFactory` is implemented, which uses dynamic method
 
 If you want to try some other implementation (for example based on reflexion) you can redefine property `Database.DefaultModelFactory`.
 
-```c#
+```CSharp
 Database.DefaultModelFactory = new ReflectionModelfactory();
 ```
 
@@ -377,7 +377,7 @@ You can use Kros.KORM also for editing, adding or deleting records from database
 
 Records to edit or delete are identified by the primary key. You can set primary key to your POCO class by using `Key` attribute.
 
-```c#
+```CSharp
 [Key()]
 public int Id { get; set; }
 
@@ -388,7 +388,7 @@ public string LastName { get; set; }
 
 #### Inserting records to database
 
-```c#
+```CSharp
 public void Insert()
 {
     using (var database = new Database(_connection))
@@ -405,7 +405,7 @@ public void Insert()
 
 Kros.KORM supports bulk inserting, which is one of its best features. You add records to DbSet standardly by method ```Add```, but for committing to database use method ```BulkInsert``` instead of ```CommitChanges```.
 
-```c#
+```CSharp
 var people = database.Query<Person>().AsDbSet();
 
 foreach (var person in dataForImport)
@@ -418,7 +418,7 @@ people.BulkInsert();
 
 Kros.KORM supports also bulk update of records, you can use ```BulkUpdate``` method.
 
-```c#
+```CSharp
 var people = database.Query<Person>().AsDbSet();
 
 foreach (var person in dataForUpdate)
@@ -443,7 +443,7 @@ Support two types of generating:
 
 Primary key must be simple `Int32` column. Primary key property in POCO class must be decorated by `Key` attribute and its property `AutoIncrementMethodType` must be set to `Custom`.
 
-```c#
+```CSharp
 [Key(autoIncrementMethodType: AutoIncrementMethodType.Custom)]
 public int Id { get; set; }
 ```
@@ -465,7 +465,7 @@ CONSTRAINT [PK_Users] PRIMARY KEY CLUSTERED
 ) ON [PRIMARY]
 ```
 
-```c#
+```CSharp
 [Key(autoIncrementMethodType: AutoIncrementMethodType.Identity)]
 public long Id { get; set; }
 ```
@@ -475,7 +475,7 @@ When you call `dbSet.CommitChanges()`, Kros.KORM fill generated keys into entity
 
 #### Editing records in database
 
-```c#
+```CSharp
 public void Edit()
 {
     using (var database = new Database(_connection))
@@ -493,9 +493,9 @@ public void Edit()
 }
 ```
 
-### Deleting records from database
+#### Deleting records from database
 
-```c#
+```CSharp
 public void Delete()
 {
     using (var database = new Database(_connection))
@@ -510,13 +510,30 @@ public void Delete()
 }
 ```
 
+##### Deleting records by Ids or condition
+
+```CSharp
+public void Delete()
+{
+    using (var database = new Database(_connection))
+    {
+        var people = database.Query<Person>().AsDbSet();
+
+        people.Delete(1);
+        people.Delete(p => p.ParentId == 10);
+
+        people.CommitChangesAsync();
+    }
+}
+```
+
 #### Explicit transactions
 
 By default, changes of a `DbSet` are committed to database in a transaction. If committing of one record fails, rollback of transaction is executed.
 
 Sometimes you might come to situation, when such implicit transaction would not meet your requirements. For example you need to commit changes to two tables as an atomic operation. When saving changes to first of tables is not successful, you want to discard changes to the other table. Solution of that task is easy with explicit transactions supported by Kros.KORM. See the documentation of [BeginTransaction](https://kros-sk.github.io/Kros.Libs.Documentation/api/Kros.KORM/Kros.KORM.IDatabase.html#Kros_KORM_IDatabase_BeginTransaction).
 
-```c#
+```CSharp
 using (var transaction = database.BeginTransaction())
 {
     var invoicesDbSet = database.Query<Invoice>().AsDbSet();
@@ -539,13 +556,27 @@ using (var transaction = database.BeginTransaction())
 }
 ```
 
+#### Simplify Adding, Deleting and Editing records
+
+For simplifying calling methods (`Add`, `Edit`, `Delete`) use extension methods from `IDatabaseExtensions` class.
+
+```CSharp
+await database.AddAsync(person);
+await database.DeleteAsync(person);
+await database.DeleteAsync<Person>(2);
+await database.DeleteAsync<Person>(p => p.Id == 2);
+await database.DeleteAsync<Person>("Id = @1", 2);
+await database.EditAsync(person);
+await database.EditAsync(person, "Id", "Age");
+```
+
 ### SQL commands executing
 
 Kros.KORM supports SQL commands execution. There are three types of commands:
 
 * ```ExecuteNonQuery``` for commands that do not return value (DELETE, UPDATE, ...)
 
-  ```c#
+  ```CSharp
   private Database _database = new Database(new SqlConnection("connection string"));
 
   // to work with command parameters you can use CommandParameterCollection
@@ -566,7 +597,7 @@ Kros.KORM supports SQL commands execution. There are three types of commands:
 
 #### Execution of stored procedure example
 
-```c#
+```CSharp
 public class Person
 {
     public int Id { get; set; }
@@ -606,7 +637,7 @@ If you want to execute time-consuming command, you will definitely appreciate `C
 
 Warning: You can set `CommandTimeout` only for main transaction, not for nested transactions. In that case CommandTimout of main transaction will be used.
 
-```c#
+```CSharp
 IEnumerable<Person> persons = null;
 
 using (var transaction = database.BeginTransaction(IsolationLevel.Chaos))
@@ -629,7 +660,7 @@ using (var transaction = database.BeginTransaction(IsolationLevel.Chaos))
 
 Kros.KORM offers the ability to log each generated and executed query. All you have to do is add this line to your source code.
 
-```c#
+```CSharp
 Database.Log = Console.WriteLine;
 ```
 
@@ -639,7 +670,7 @@ Kros.KORM uses its own [QueryProvider](https://kros-sk.github.io/Kros.Libs.Docum
 
 MsAccess is suported from version 2.4 in Kros.KORM.MsAccess library. If you need to work with MS Access database, you have to refer this library in your project and register [MsAccessQueryProviderFactory](https://kros-sk.github.io/Kros.Libs.Documentation/api/Kros.KORM.MsAccess/Kros.KORM.Query.MsAccess.MsAccessQueryProviderFactory.html).
 
-```c#
+```CSharp
 MsAccessQueryProviderFactory.Register();
 ```
 
@@ -647,7 +678,7 @@ Current version of Kros.KORM suports databases MS ACCESS and MS SQL.
 
 If you want to support a different database engine, you can implement your own [IQueryProvider](https://kros-sk.github.io/Kros.Libs.Documentation/api/Kros.KORM/Kros.KORM.Query.IQueryProvider.html). And register it in [QueryProviderFactories](https://kros-sk.github.io/Kros.Libs.Documentation/api/Kros.KORM/Kros.KORM.Query.QueryProviderFactories.html).
 
-```c#
+```CSharp
 public class CustomQueryProvider : QueryProvider
 {
     public CustomQueryProvider(ConnectionStringSettings connectionString,

--- a/src/CommandGenerator/CommandGenerator.cs
+++ b/src/CommandGenerator/CommandGenerator.cs
@@ -3,6 +3,7 @@ using Kros.KORM.Metadata;
 using Kros.KORM.Properties;
 using Kros.KORM.Query;
 using Kros.KORM.Query.Expressions;
+using Kros.KORM.Query.Sql;
 using Kros.Utils;
 using System;
 using System.Collections;
@@ -127,6 +128,17 @@ namespace Kros.KORM.CommandGenerator
             DbCommand cmd = _provider.GetCommandForCurrentTransaction();
             AddParametersToCommand(cmd, columns);
             cmd.CommandText = GetDeleteCommandText(columns);
+            return cmd;
+        }
+
+        /// <inheritdoc />
+        public DbCommand GetDeleteCommand(WhereExpression whereExpression)
+        {
+            DbCommand cmd = _provider.GetCommandForCurrentTransaction();
+
+            cmd.CommandText = string.Format(DELETE_QUERY_BASE, _tableInfo.Name, whereExpression.Sql);
+            ParameterExtractingExpressionVisitor.ExtractParametersToCommand(cmd, whereExpression);
+
             return cmd;
         }
 

--- a/src/CommandGenerator/CommandGenerator.cs
+++ b/src/CommandGenerator/CommandGenerator.cs
@@ -5,6 +5,7 @@ using Kros.KORM.Query;
 using Kros.KORM.Query.Expressions;
 using Kros.Utils;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
@@ -129,14 +130,8 @@ namespace Kros.KORM.CommandGenerator
             return cmd;
         }
 
-        /// <summary>
-        /// Gets the automatically generated DbCommands object required to perform deletions on the database.
-        /// </summary>
-        /// <param name="items">Type class of model collection.</param>
-        /// <exception cref="Exceptions.MissingPrimaryKeyException">Table does not have primary key.</exception>
-        /// <exception cref="Exceptions.CompositePrimaryKeyException">Table has composite primary key.</exception>
-        /// <returns>Delete command collection.</returns>
-        public IEnumerable<DbCommand> GetDeleteCommands(IEnumerable<T> items)
+        /// <inheritdoc />
+        public IEnumerable<DbCommand> GetDeleteCommands(IEnumerable ids)
         {
             CheckPrimaryKeyExist(string.Format(Resources.MethodNotSupportedWhenNoPrimaryKey, nameof(GetDeleteCommands)));
 
@@ -153,7 +148,7 @@ namespace Kros.KORM.CommandGenerator
             var deleteQueryText = new StringBuilder();
             int iterationCount = 0;
 
-            foreach (T item in items)
+            foreach (object id in ids)
             {
                 if (iterationCount == 0)
                 {
@@ -164,7 +159,7 @@ namespace Kros.KORM.CommandGenerator
 
                 iterationCount++;
                 string paramterName = $"@P{iterationCount}";
-                AddDeleteCommandParameter(cmd, paramterName, GetColumnValue(colInfo, item));
+                AddDeleteCommandParameter(cmd, paramterName, id);
                 if (iterationCount > 1)
                 {
                     deleteQueryText.Append(",");

--- a/src/CommandGenerator/CommandGenerator.cs
+++ b/src/CommandGenerator/CommandGenerator.cs
@@ -105,7 +105,7 @@ namespace Kros.KORM.CommandGenerator
         /// <returns>Update command.</returns>
         public DbCommand GetUpdateCommand()
         {
-            CheckPrimaryKeyExist(string.Format(Resources.MethodNotSupportedWhenNoPrimaryKey, nameof(GetUpdateCommand)));
+            ThrowHelper.CheckAndThrowMethodNotSupportedWhenNoPrimaryKey(_tableInfo);
 
             IEnumerable<ColumnInfo> columns = GetQueryColumns();
             DbCommand cmd = _provider.GetCommandForCurrentTransaction();
@@ -122,7 +122,7 @@ namespace Kros.KORM.CommandGenerator
         /// <returns>Delete command.</returns>
         public DbCommand GetDeleteCommand()
         {
-            CheckPrimaryKeyExist(string.Format(Resources.MethodNotSupportedWhenNoPrimaryKey, nameof(GetDeleteCommand)));
+            ThrowHelper.CheckAndThrowMethodNotSupportedWhenNoPrimaryKey(_tableInfo);
 
             IEnumerable<ColumnInfo> columns = _tableInfo.PrimaryKey;
             DbCommand cmd = _provider.GetCommandForCurrentTransaction();
@@ -145,14 +145,8 @@ namespace Kros.KORM.CommandGenerator
         /// <inheritdoc />
         public IEnumerable<DbCommand> GetDeleteCommands(IEnumerable ids)
         {
-            CheckPrimaryKeyExist(string.Format(Resources.MethodNotSupportedWhenNoPrimaryKey, nameof(GetDeleteCommands)));
-
-            if (_tableInfo.PrimaryKey.Count() > 1)
-            {
-                throw new Exceptions.CompositePrimaryKeyException(
-                    string.Format(Resources.MethodNotSupportedForCompositePrimaryKey, nameof(GetDeleteCommands)),
-                    _tableInfo.Name);
-            }
+            ThrowHelper.CheckAndThrowMethodNotSupportedWhenNoPrimaryKey(_tableInfo);
+            ThrowHelper.CheckAndThrowMethodNotSupportedForCompositePrimaryKey(_tableInfo);
 
             var retVal = new List<DbCommand>();
             ColumnInfo colInfo = _tableInfo.PrimaryKey.First();
@@ -214,14 +208,6 @@ namespace Kros.KORM.CommandGenerator
                     var val = GetColumnValue(colInfo, item);
                     parameter.Value = val ?? System.DBNull.Value;
                 }
-            }
-        }
-
-        private void CheckPrimaryKeyExist(string message)
-        {
-            if (_tableInfo.PrimaryKey.Count() == 0)
-            {
-                throw new Exceptions.MissingPrimaryKeyException(message, _tableInfo.Name);
             }
         }
 

--- a/src/CommandGenerator/ICommandGenerator.cs
+++ b/src/CommandGenerator/ICommandGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using Kros.KORM.Metadata;
+using Kros.KORM.Query.Expressions;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
@@ -40,6 +41,8 @@ namespace Kros.KORM.CommandGenerator
         /// <exception cref="Exceptions.CompositePrimaryKeyException">Table has composite primary key.</exception>
         /// <returns>Delete command collection.</returns>
         IEnumerable<DbCommand> GetDeleteCommands(IEnumerable ids);
+
+        DbCommand GetDeleteCommand(WhereExpression whereExpression);
 
         /// <summary>
         /// Fills command's parameters with values from <paramref name="item" />.

--- a/src/CommandGenerator/ICommandGenerator.cs
+++ b/src/CommandGenerator/ICommandGenerator.cs
@@ -42,6 +42,11 @@ namespace Kros.KORM.CommandGenerator
         /// <returns>Delete command collection.</returns>
         IEnumerable<DbCommand> GetDeleteCommands(IEnumerable ids);
 
+        /// <summary>
+        /// Get delete command with specific condition.
+        /// </summary>
+        /// <param name="whereExpression">Where condition for DELETE statement.</param>
+        /// <returns>Delete command.</returns>
         DbCommand GetDeleteCommand(WhereExpression whereExpression);
 
         /// <summary>

--- a/src/CommandGenerator/ICommandGenerator.cs
+++ b/src/CommandGenerator/ICommandGenerator.cs
@@ -37,7 +37,7 @@ namespace Kros.KORM.CommandGenerator
         /// Gets the automatically generated DbCommands object required to perform deletions on the database.
         /// </summary>
         /// <param name="ids">Items ids to delete.</param>
-        /// <exception cref="Exceptions.MissingPrimaryKeyException">GetDeleteCommands doesn't supported when entity doesn't have primary key.</exception>
+        /// <exception cref="Exceptions.MissingPrimaryKeyException"><c>GetDeleteCommands</c> is not supported when entity doesn't have primary key.</exception>
         /// <exception cref="Exceptions.CompositePrimaryKeyException">Table has composite primary key.</exception>
         /// <returns>Delete command collection.</returns>
         IEnumerable<DbCommand> GetDeleteCommands(IEnumerable ids);

--- a/src/CommandGenerator/ICommandGenerator.cs
+++ b/src/CommandGenerator/ICommandGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using Kros.KORM.Metadata;
+using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
 
@@ -34,10 +35,11 @@ namespace Kros.KORM.CommandGenerator
         /// <summary>
         /// Gets the automatically generated DbCommands object required to perform deletions on the database.
         /// </summary>
-        /// <param name="items">Type class of model collection.</param>
+        /// <param name="ids">Items ids to delete.</param>
         /// <exception cref="Exceptions.MissingPrimaryKeyException">GetDeleteCommands doesn't supported when entity doesn't have primary key.</exception>
+        /// <exception cref="Exceptions.CompositePrimaryKeyException">Table has composite primary key.</exception>
         /// <returns>Delete command collection.</returns>
-        IEnumerable<DbCommand> GetDeleteCommands(IEnumerable<T> items);
+        IEnumerable<DbCommand> GetDeleteCommands(IEnumerable ids);
 
         /// <summary>
         /// Fills command's parameters with values from <paramref name="item" />.

--- a/src/IDatabaseExtensions.cs
+++ b/src/IDatabaseExtensions.cs
@@ -1,0 +1,101 @@
+﻿using Kros.KORM.Query;
+using Kros.KORM.Query.Sql;
+using System;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace Kros.KORM
+{
+    /// <summary>
+    /// Extensions over <see cref="IDatabase"/>.
+    /// </summary>
+    public static class IDatabaseExtensions
+    {
+        /// <summary>
+        /// Adds the <paramref name="entity"/> to the database.
+        /// </summary>
+        /// <typeparam name="TEntity">Entity type.</typeparam>
+        /// <param name="database"><see cref="IDatabase"/> instance.</param>
+        /// <param name="entity">The entity to add.</param>
+        public static async Task AddAsync<TEntity>(this IDatabase database, TEntity entity) where TEntity : class
+            => await CommitChangesAsync(database, (IDbSet<TEntity> dbSet) => dbSet.Add(entity));
+
+        /// <summary>
+        /// Deletes the <paramref name="entity"/> from the database.
+        /// </summary>
+        /// <typeparam name="TEntity">Entity type.</typeparam>
+        /// <param name="database"><see cref="IDatabase"/> instance.</param>
+        /// <param name="entity">The entity to delete.</param>
+        public static async Task DeleteAsync<TEntity>(this IDatabase database, TEntity entity) where TEntity : class
+            => await CommitChangesAsync(database, (IDbSet<TEntity> dbSet) => dbSet.Delete(entity));
+
+        /// <summary>
+        /// Deletes the <typeparamref name="TEntity"/> with <paramref name="id"/> from the database.
+        /// </summary>
+        /// <typeparam name="TEntity">Entity type.</typeparam>
+        /// <param name="database"><see cref="IDatabase"/> instance.</param>
+        /// <param name="id">The entity id to delete.</param>
+        public static async Task DeleteAsync<TEntity>(this IDatabase database, object id) where TEntity : class
+            => await CommitChangesAsync(database, (IDbSet<TEntity> dbSet) => dbSet.Delete(id));
+
+        /// <summary>
+        /// Deletes the <typeparamref name="TEntity"/> from the database by <paramref name="condition"/>.
+        /// </summary>
+        /// <typeparam name="TEntity">Entity type.</typeparam>
+        /// <param name="database"><see cref="IDatabase"/> instance.</param>
+        /// <param name="condition">The delete condition.</param>
+        public static async Task DeleteAsync<TEntity>(
+            this IDatabase database,
+            Expression<Func<TEntity, bool>> condition) where TEntity : class
+            => await CommitChangesAsync(database, (IDbSet<TEntity> dbSet) => dbSet.Delete(condition));
+
+        /// <summary>
+        /// Deletes the <typeparamref name="TEntity"/> from the database by <paramref name="condition"/>.
+        /// </summary>
+        /// <typeparam name="TEntity">Entity type.</typeparam>
+        /// <param name="database"><see cref="IDatabase"/> instance.</param>
+        /// <param name="condition">The delete condition.</param>
+        /// <param name="parameters">Condition parameters.</param>
+        public static async Task DeleteAsync<TEntity>(
+            this IDatabase database,
+            RawSqlString condition,
+            params object[] parameters) where TEntity : class
+            => await CommitChangesAsync(database, (IDbSet<TEntity> dbSet) => dbSet.Delete(condition, parameters));
+
+        /// <summary>
+        /// Edits the <paramref name="entity"/> in the database.
+        /// </summary>
+        /// <typeparam name="TEntity">Entity type.</typeparam>
+        /// <param name="database"><see cref="IDatabase"/> instance.</param>
+        /// <param name="entity">The entity to edit.</param>
+        public static async Task EditAsync<TEntity>(this IDatabase database, TEntity entity) where TEntity : class
+            => await CommitChangesAsync(database, (IDbSet<TEntity> dbSet) => dbSet.Edit(entity));
+
+        /// <summary>
+        /// Edits the <paramref name="entity"/> in the database.
+        /// </summary>
+        /// <typeparam name="TEntity">Entity type.</typeparam>
+        /// <param name="database"><see cref="IDatabase"/> instance.</param>
+        /// <param name="entity">The entity to edit.</param>
+        /// <param name="columns">Columns for editing.</param>
+        public static async Task EditAsync<TEntity>(
+            this IDatabase database,
+            TEntity entity,
+            params string[] columns) where TEntity : class
+            => await CommitChangesAsync(database, (IDbSet<TEntity> dbSet) => dbSet.Edit(entity), columns);
+
+        private static async Task CommitChangesAsync<TEntity>(
+            IDatabase database,
+            Action<IDbSet<TEntity>> action,
+            params string[] columns) where TEntity : class
+        {
+            IDbSet<TEntity> dbSet = columns.Length == 0
+                ? database.Query<TEntity>().AsDbSet()
+                : database.Query<TEntity>().Select(columns).AsDbSet();
+
+            action(dbSet);
+
+            await dbSet.CommitChangesAsync();
+        }
+    }
+}

--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -214,7 +214,7 @@ namespace Kros.KORM.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot delete item with Id = &apos;{0}&apos;. This item with this Id already exists in collection..
+        ///   Looks up a localized string similar to Cannot delete item with Id &apos;{0}&apos;. Item with this Id is already marked for deleting..
         /// </summary>
         internal static string ExistingItemIdCannotBeDeleted {
             get {
@@ -232,20 +232,20 @@ namespace Kros.KORM.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid type of id parameter. Property which represent primary key is type of &apos;{0}&apos;..
-        /// </summary>
-        internal static string InvalidIdParameterType {
-            get {
-                return ResourceManager.GetString("InvalidIdParameterType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Table {0} has none, or composite primary key. Primary key must be one column only..
         /// </summary>
         internal static string InvalidPrimaryKeyForBulkUpdate {
             get {
                 return ResourceManager.GetString("InvalidPrimaryKeyForBulkUpdate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid type of id value. Property which represents primary key is of type &apos;{0}&apos;, but the value&apos;s type is `{1}`..
+        /// </summary>
+        internal static string InvalidPrimaryKeyValueType {
+            get {
+                return ResourceManager.GetString("InvalidPrimaryKeyValueType", resourceCulture);
             }
         }
         

--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -214,11 +214,29 @@ namespace Kros.KORM.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot delete item with Id = &apos;{0}&apos;. This item with this Id already exists in collection..
+        /// </summary>
+        internal static string ExistingItemIdCannotBeDeleted {
+            get {
+                return ResourceManager.GetString("ExistingItemIdCannotBeDeleted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} can be applied only once..
         /// </summary>
         internal static string ExpressionCanBeAppliedOnlyOnce {
             get {
                 return ResourceManager.GetString("ExpressionCanBeAppliedOnlyOnce", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid type of id parameter. Property which represent primary key is type of &apos;{0}&apos;..
+        /// </summary>
+        internal static string InvalidIdParameterType {
+            get {
+                return ResourceManager.GetString("InvalidIdParameterType", resourceCulture);
             }
         }
         

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -170,8 +170,15 @@
   <data name="ExistingItemCannotBeEdited" xml:space="preserve">
     <value>Cannot edit item (hash code = {0}). This item already exists in collection {1}.</value>
   </data>
+  <data name="ExistingItemIdCannotBeDeleted" xml:space="preserve">
+    <value>Cannot delete item with Id = '{0}'. This item with this Id already exists in collection.</value>
+  </data>
   <data name="ExpressionCanBeAppliedOnlyOnce" xml:space="preserve">
     <value>{0} can be applied only once.</value>
+  </data>
+  <data name="InvalidIdParameterType" xml:space="preserve">
+    <value>Invalid type of id parameter. Property which represent primary key is type of '{0}'.</value>
+    <comment>0 - type of property which represent primary key</comment>
   </data>
   <data name="InvalidPrimaryKeyForBulkUpdate" xml:space="preserve">
     <value>Table {0} has none, or composite primary key. Primary key must be one column only.</value>

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -171,17 +171,19 @@
     <value>Cannot edit item (hash code = {0}). This item already exists in collection {1}.</value>
   </data>
   <data name="ExistingItemIdCannotBeDeleted" xml:space="preserve">
-    <value>Cannot delete item with Id = '{0}'. This item with this Id already exists in collection.</value>
+    <value>Cannot delete item with Id '{0}'. Item with this Id is already marked for deleting.</value>
   </data>
   <data name="ExpressionCanBeAppliedOnlyOnce" xml:space="preserve">
     <value>{0} can be applied only once.</value>
   </data>
-  <data name="InvalidIdParameterType" xml:space="preserve">
-    <value>Invalid type of id parameter. Property which represent primary key is type of '{0}'.</value>
-    <comment>0 - type of property which represent primary key</comment>
-  </data>
   <data name="InvalidPrimaryKeyForBulkUpdate" xml:space="preserve">
     <value>Table {0} has none, or composite primary key. Primary key must be one column only.</value>
+  </data>
+  <data name="InvalidPrimaryKeyValueType" xml:space="preserve">
+    <value>Invalid type of id value. Property which represents primary key is of type '{0}', but the value's type is `{1}`.</value>
+    <comment>0 - type of property which represent primary key
+1 - type of input value
+</comment>
   </data>
   <data name="LimitOffsetDataReaderInnerReaderAlreadySet" xml:space="preserve">
     <value>Inner reader is already set. It can be set only once.</value>

--- a/src/Query/DbSet.cs
+++ b/src/Query/DbSet.cs
@@ -168,15 +168,6 @@ namespace Kros.KORM.Query
             }
         }
 
-        /// <inheritdoc />
-        public void Delete(IEnumerable<object> ids)
-        {
-            foreach (object id in ids)
-            {
-                Delete(id);
-            }
-        }
-
         /// <summary>
         /// Clear Added, Edited and Deleted lists of items.
         /// </summary>

--- a/src/Query/DbSet.cs
+++ b/src/Query/DbSet.cs
@@ -133,11 +133,11 @@ namespace Kros.KORM.Query
         }
 
         /// <inheritdoc />
-        public void Delete(RawSqlString whereCondition, params object[] parameters)
+        public void Delete(RawSqlString condition, params object[] parameters)
         {
-            Check.NotNull(whereCondition, nameof(whereCondition));
+            Check.NotNull(condition, nameof(condition));
 
-            var where = new WhereExpression(whereCondition, parameters);
+            var where = new WhereExpression(condition, parameters);
 
             _deleteExpressions.Add(where);
         }
@@ -496,7 +496,6 @@ namespace Kros.KORM.Query
                 }
             }
         }
-
 
         private void CheckItemInCollection(T entity, HashSet<T> collection, string message, string collectionName)
         {

--- a/src/Query/IDbSet.cs
+++ b/src/Query/IDbSet.cs
@@ -58,10 +58,10 @@ namespace Kros.KORM.Query
         /// </summary>
         /// <param name="id">The item id to delete.</param>
         /// <exception cref="Exceptions.MissingPrimaryKeyException">
-        /// Delete method doesn't supported when entity doesn't have primary key.
+        /// Delete method is not supported when entity doesn't have primary key.
         /// </exception>
         /// <exception cref="Exceptions.CompositePrimaryKeyException">
-        /// Delete method doesn't supported when entity has composite primary key.
+        /// Delete method is not supported when entity has composite primary key.
         /// </exception>
         /// <exception cref="ArgumentException">
         /// When type of <paramref name="id"/> is different from primary key property type.

--- a/src/Query/IDbSet.cs
+++ b/src/Query/IDbSet.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
@@ -55,13 +54,31 @@ namespace Kros.KORM.Query
         /// Marks the item id as Deleted such the item with this id will be deleted from the database when CommitChanges is called.
         /// </summary>
         /// <param name="id">The item id to delete.</param>
+        /// <exception cref="Exceptions.MissingPrimaryKeyException">
+        /// Delete method doesn't supported when entity doesn't have primary key.
+        /// </exception>
+        /// <exception cref="Exceptions.CompositePrimaryKeyException">
+        /// Delete method doesn't supported when entity has composite primary key.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// When type of <paramref name="id"/> is different from primary key property type.
+        /// </exception>
         void Delete(object id);
 
         /// <summary>
         /// Marks the items ids as Deleted such items with these ids it will be deleted from the database when CommitChanges is called.
         /// </summary>
         /// <param name="ids">The items ids to delete.</param>
-        void Delete(IEnumerable ids);
+        /// <exception cref="Exceptions.MissingPrimaryKeyException">
+        /// Delete method doesn't supported when entity doesn't have primary key.
+        /// </exception>
+        /// <exception cref="Exceptions.CompositePrimaryKeyException">
+        /// Delete method doesn't supported when entity has composite primary key.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// When type of <paramref name="id"/> is different from primary key property type.
+        /// </exception>
+        void Delete(IEnumerable<object> ids);
 
         /// <summary>
         /// Rolls back all pending changes.

--- a/src/Query/IDbSet.cs
+++ b/src/Query/IDbSet.cs
@@ -79,9 +79,9 @@ namespace Kros.KORM.Query
         /// Delete items by condition.
         /// These items will be deleted from the database when <see cref="CommitChanges"/> is called.
         /// </summary>
-        /// <param name="whereCondition">Delete condition.</param>
+        /// <param name="condition">Delete condition.</param>
         /// <param name="parameters">Condition parameters.</param>
-        void Delete(RawSqlString whereCondition, params object[] parameters);
+        void Delete(RawSqlString condition, params object[] parameters);
 
         /// <summary>
         /// Rolls back all pending changes.

--- a/src/Query/IDbSet.cs
+++ b/src/Query/IDbSet.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿using Kros.KORM.Query.Sql;
+using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 namespace Kros.KORM.Query
@@ -64,6 +66,10 @@ namespace Kros.KORM.Query
         /// When type of <paramref name="id"/> is different from primary key property type.
         /// </exception>
         void Delete(object id);
+
+        void Delete(Expression<Func<T, bool>> condition);
+
+        void Delete(RawSqlString whereCondition, params object[] parameters);
 
         /// <summary>
         /// Rolls back all pending changes.

--- a/src/Query/IDbSet.cs
+++ b/src/Query/IDbSet.cs
@@ -66,21 +66,6 @@ namespace Kros.KORM.Query
         void Delete(object id);
 
         /// <summary>
-        /// Marks the items ids as Deleted such items with these ids it will be deleted from the database when CommitChanges is called.
-        /// </summary>
-        /// <param name="ids">The items ids to delete.</param>
-        /// <exception cref="Exceptions.MissingPrimaryKeyException">
-        /// Delete method doesn't supported when entity doesn't have primary key.
-        /// </exception>
-        /// <exception cref="Exceptions.CompositePrimaryKeyException">
-        /// Delete method doesn't supported when entity has composite primary key.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// When type of <paramref name="id"/> is different from primary key property type.
-        /// </exception>
-        void Delete(IEnumerable<object> ids);
-
-        /// <summary>
         /// Rolls back all pending changes.
         /// </summary>
         void Clear();

--- a/src/Query/IDbSet.cs
+++ b/src/Query/IDbSet.cs
@@ -53,7 +53,8 @@ namespace Kros.KORM.Query
         void Delete(IEnumerable<T> entities);
 
         /// <summary>
-        /// Marks the item id as Deleted such the item with this id will be deleted from the database when CommitChanges is called.
+        /// Marks the item id as Deleted such the item with
+        /// this id will be deleted from the database when <see cref="CommitChanges"/> is called.
         /// </summary>
         /// <param name="id">The item id to delete.</param>
         /// <exception cref="Exceptions.MissingPrimaryKeyException">
@@ -67,8 +68,19 @@ namespace Kros.KORM.Query
         /// </exception>
         void Delete(object id);
 
+        /// <summary>
+        /// Delete items by condition.
+        /// These items will be deleted from the database when <see cref="CommitChanges"/> is called.
+        /// </summary>
+        /// <param name="condition">Delete condition.</param>
         void Delete(Expression<Func<T, bool>> condition);
 
+        /// <summary>
+        /// Delete items by condition.
+        /// These items will be deleted from the database when <see cref="CommitChanges"/> is called.
+        /// </summary>
+        /// <param name="whereCondition">Delete condition.</param>
+        /// <param name="parameters">Condition parameters.</param>
         void Delete(RawSqlString whereCondition, params object[] parameters);
 
         /// <summary>

--- a/src/Query/IDbSet.cs
+++ b/src/Query/IDbSet.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
@@ -49,6 +50,18 @@ namespace Kros.KORM.Query
         /// </summary>
         /// <param name="entities">The items to delete.</param>
         void Delete(IEnumerable<T> entities);
+
+        /// <summary>
+        /// Marks the item id as Deleted such the item with this id will be deleted from the database when CommitChanges is called.
+        /// </summary>
+        /// <param name="id">The item id to delete.</param>
+        void Delete(object id);
+
+        /// <summary>
+        /// Marks the items ids as Deleted such items with these ids it will be deleted from the database when CommitChanges is called.
+        /// </summary>
+        /// <param name="ids">The items ids to delete.</param>
+        void Delete(IEnumerable ids);
 
         /// <summary>
         /// Rolls back all pending changes.

--- a/src/Query/Providers/IQueryProvider.cs
+++ b/src/Query/Providers/IQueryProvider.cs
@@ -2,6 +2,7 @@
 using Kros.Data.BulkActions;
 using Kros.KORM.Data;
 using Kros.KORM.Materializer;
+using Kros.KORM.Query.Sql;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -258,5 +259,7 @@ namespace Kros.KORM.Query
         /// <param name="batchSize">Size of inserting the batch.</param>
         /// <returns>The identifier generator.</returns>
         IIdGenerator CreateIdGenerator(string tableName, int batchSize);
+
+        ISqlExpressionVisitor GetExpressionVisitor();
     }
 }

--- a/src/Query/Providers/IQueryProvider.cs
+++ b/src/Query/Providers/IQueryProvider.cs
@@ -260,6 +260,10 @@ namespace Kros.KORM.Query
         /// <returns>The identifier generator.</returns>
         IIdGenerator CreateIdGenerator(string tableName, int batchSize);
 
+        /// <summary>
+        /// Get expression visitor for generating sql.
+        /// </summary>
+        /// <returns><see cref="ISqlExpressionVisitor"/></returns>
         ISqlExpressionVisitor GetExpressionVisitor();
     }
 }

--- a/src/Query/Providers/QueryProvider.cs
+++ b/src/Query/Providers/QueryProvider.cs
@@ -542,6 +542,9 @@ namespace Kros.KORM.Query
             return new IdGeneratorHelper(factory.GetGenerator(tableName, batchSize), connection);
         }
 
+        /// <inheritdoc />
+        public ISqlExpressionVisitor GetExpressionVisitor() => _sqlGeneratorFactory.CreateVisitor(Connection);
+
         #endregion
 
         #region Linq

--- a/src/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -70,6 +70,19 @@ namespace Kros.KORM.Query.Sql
             return new QueryInfo(SqlBuilder.ToString(), CreateQueryReader());
         }
 
+        /// <inheritdoc />
+        public WhereExpression GenerateWhereCondition(Expression whereExpression)
+        {
+            Check.NotNull(whereExpression, nameof(whereExpression));
+
+            LinqParameters = new Parameters();
+            LinqStringBuilder = new StringBuilder();
+
+            Visit(whereExpression);
+
+            return new WhereExpression(LinqStringBuilder.ToString(), LinqParameters.GetParams());
+        }
+
         /// <summary>
         /// List of ORDER BY parts for the query.
         /// </summary>

--- a/src/Query/Sql/ISqlExpressionVisitor.cs
+++ b/src/Query/Sql/ISqlExpressionVisitor.cs
@@ -15,6 +15,8 @@ namespace Kros.KORM.Query.Sql
         /// <returns>SQL select command text.</returns>
         QueryInfo GenerateSql(Expression expression);
 
+        WhereExpression GenerateWhereCondition(Expression whereExpression);
+
         /// <summary>
         /// Visits the SQL.
         /// </summary>

--- a/src/Query/Sql/ISqlExpressionVisitor.cs
+++ b/src/Query/Sql/ISqlExpressionVisitor.cs
@@ -15,6 +15,16 @@ namespace Kros.KORM.Query.Sql
         /// <returns>SQL select command text.</returns>
         QueryInfo GenerateSql(Expression expression);
 
+        /// <summary>
+        /// Generate the SQL WHERE condition from <paramref name="whereExpression"/>.
+        /// </summary>
+        /// <param name="whereExpression">Where condition written by LINQ expression.</param>
+        /// <returns>
+        /// <see cref="WhereExpression"/> which contains generated SQL WHERE condition and parameters.
+        /// </returns>
+        /// <remarks>
+        /// SQL WHERE condition is generated without WHERE keyword.
+        /// </remarks>
         WhereExpression GenerateWhereCondition(Expression whereExpression);
 
         /// <summary>

--- a/src/ThrowHelper.cs
+++ b/src/ThrowHelper.cs
@@ -1,6 +1,9 @@
 ﻿using Kros.KORM.Converter;
+using Kros.KORM.Metadata;
 using Kros.KORM.Properties;
 using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Kros.KORM
 {
@@ -26,5 +29,27 @@ namespace Kros.KORM
             => throw new InvalidOperationException(
                 string.Format(Resources.ThrowHelper_ConverterForTypeAlreadyConfigured,
                     converter.GetType().FullName, propertyType.Name, typeof(TEntity).Name, currentConverter.GetType().FullName));
-    }
+
+        public static void CheckAndThrowMethodNotSupportedWhenNoPrimaryKey(
+            TableInfo tableInfo,
+            [CallerMemberName] string methodName = null)
+        {
+            if (!tableInfo.PrimaryKey.Any())
+            {
+                throw new Exceptions.MissingPrimaryKeyException(
+                    string.Format(Resources.MethodNotSupportedWhenNoPrimaryKey, methodName), tableInfo.Name);
+            }
+        }
+
+        public static void CheckAndThrowMethodNotSupportedForCompositePrimaryKey(
+            TableInfo tableInfo,
+            [CallerMemberName] string methodName = null)
+        {
+            if (tableInfo.PrimaryKey.Count() > 1)
+            {
+                throw new Exceptions.CompositePrimaryKeyException(
+                    string.Format(Resources.MethodNotSupportedForCompositePrimaryKey, methodName), tableInfo.Name);
+            }
+        }
+}
 }

--- a/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
+++ b/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
@@ -67,7 +67,7 @@ namespace Kros.KORM.UnitTests.CommandGenerator
         {
             const string expectedQuery = "DELETE FROM [Foo] WHERE [IdRow] IN (@P1,@P2,@P3,@P4,@P5,@P6,@P7,@P8,@P9,@P10,@P11,@P12,@P13,@P14,@P15)";
 
-            var result = GetFooGenerator().GetDeleteCommands(GetFooList(15)).ToList();
+            var result = GetFooGenerator().GetDeleteCommands(Enumerable.Range(1, 15)).ToList();
 
             result.Should().HaveCount(1);
             result[0].CommandText.Should().Be(expectedQuery);
@@ -86,7 +86,7 @@ namespace Kros.KORM.UnitTests.CommandGenerator
             CommandGenerator<Foo> generator = GetFooGenerator();
             generator.MaxParametersForDeleteCommandsInPart = 10;
 
-            var result = generator.GetDeleteCommands(GetFooList(25)).ToList();
+            var result = generator.GetDeleteCommands(Enumerable.Range(1, 25)).ToList();
 
             result.Should().HaveCount(3);
             result[0].CommandText.Should().Be(expectedQuery_0);

--- a/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
+++ b/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
@@ -292,18 +292,6 @@ namespace Kros.KORM.UnitTests.CommandGenerator
             return new TableInfo(columns, new List<PropertyInfo>(), null) { Name = "FooIdentity" };
         }
 
-        private List<Foo> GetFooList(int itemsCount)
-        {
-            var retVal = new List<Foo>();
-
-            for (int i = 0; i < itemsCount; i++)
-            {
-                retVal.Add(new Foo() { Id = (i + 1) });
-            }
-
-            return retVal;
-        }
-
         private PropertyInfo GetPropertyInfo<T>(string propertyName) => typeof(T).GetProperty(propertyName);
 
         private class ConverterDto

--- a/tests/Kros.KORM.UnitTests/Integration/DbSetShould.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/DbSetShould.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Kros.Data.SqlServer;
 using Kros.KORM.Converter;
 using Kros.KORM.Metadata;
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using Newtonsoft.Json.Linq;
 
 namespace Kros.KORM.UnitTests.Integration
 {
@@ -130,7 +131,7 @@ $@"CREATE TABLE [dbo].[{Table_TestTable}] (
 
         private static readonly string InsertDataScript =
 $@"INSERT INTO {Table_TestTable} VALUES (1, 18, 'John', 'Smith', 'London', 'Lorem ipsum dolor sit amet 1.');
-INSERT INTO {Table_TestTable} VALUES (1, 22, 'Kilie', 'Bistrol', 'London', 'Lorem ipsum dolor sit amet 2.');";
+INSERT INTO {Table_TestTable} VALUES (2, 22, 'Kilie', 'Bistrol', 'London', 'Lorem ipsum dolor sit amet 2.');";
 
         private const string Table_LimitOffsetTest = "LimitOffsetTest";
 
@@ -294,6 +295,37 @@ INSERT INTO [{Table_LimitOffsetTest}] VALUES (20, 'twenty');";
                 await dbSet.CommitChangesAsync();
 
                 korm.Query<Person>().Count().Should().Be(0);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteDataByIdAsync()
+        {
+            using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var dbSet = korm.Query<Person>().AsDbSet();
+                dbSet.Delete(1);
+
+                await dbSet.CommitChangesAsync();
+
+                korm.Query<Person>()
+                    .Should()
+                    .NotContain(p => p.Id == 1);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteDataByIdsAsync()
+        {
+            using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var dbSet = korm.Query<Person>().AsDbSet();
+                dbSet.Delete(1);
+                dbSet.Delete(2);
+
+                await dbSet.CommitChangesAsync();
+
+                korm.Query<Person>().Should().BeEmpty();
             }
         }
 

--- a/tests/Kros.KORM.UnitTests/Integration/DbSetShould.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/DbSetShould.cs
@@ -3,16 +3,15 @@ using Kros.Data.SqlServer;
 using Kros.KORM.Converter;
 using Kros.KORM.Metadata;
 using Kros.KORM.Metadata.Attribute;
-using Kros.KORM.UnitTests.Properties;
 using Kros.KORM.Query;
 using Kros.KORM.UnitTests.Base;
+using Kros.KORM.UnitTests.Properties;
 using Nito.AsyncEx;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
-using Newtonsoft.Json.Linq;
 
 namespace Kros.KORM.UnitTests.Integration
 {
@@ -335,7 +334,23 @@ INSERT INTO [{Table_LimitOffsetTest}] VALUES (20, 'twenty');";
             using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
             {
                 var dbSet = korm.Query<Person>().AsDbSet();
-                dbSet.Delete(p=> p.Id == 1);
+                dbSet.Delete(p => p.Id == 1);
+
+                await dbSet.CommitChangesAsync();
+
+                korm.Query<Person>()
+                    .Should()
+                    .NotContain(p => p.Id == 1);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteDataByComplexLinqConditionAsync()
+        {
+            using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var dbSet = korm.Query<Person>().AsDbSet();
+                dbSet.Delete(p => p.Age >= 18 && p.Age < 20);
 
                 await dbSet.CommitChangesAsync();
 

--- a/tests/Kros.KORM.UnitTests/Integration/DbSetShould.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/DbSetShould.cs
@@ -330,7 +330,7 @@ INSERT INTO [{Table_LimitOffsetTest}] VALUES (20, 'twenty');";
         }
 
         [Fact]
-        public async Task DeleteDataByConditionAsync()
+        public async Task DeleteDataByLinqConditionAsync()
         {
             using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
             {
@@ -342,6 +342,22 @@ INSERT INTO [{Table_LimitOffsetTest}] VALUES (20, 'twenty');";
                 korm.Query<Person>()
                     .Should()
                     .NotContain(p => p.Id == 1);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteDataByConditionAsync()
+        {
+            using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var dbSet = korm.Query<Person>().AsDbSet();
+                dbSet.Delete("Id = @1", 2);
+
+                await dbSet.CommitChangesAsync();
+
+                korm.Query<Person>()
+                    .Should()
+                    .NotContain(p => p.Id == 2);
             }
         }
 

--- a/tests/Kros.KORM.UnitTests/Integration/DbSetShould.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/DbSetShould.cs
@@ -329,6 +329,22 @@ INSERT INTO [{Table_LimitOffsetTest}] VALUES (20, 'twenty');";
             }
         }
 
+        [Fact]
+        public async Task DeleteDataByConditionAsync()
+        {
+            using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var dbSet = korm.Query<Person>().AsDbSet();
+                dbSet.Delete(p=> p.Id == 1);
+
+                await dbSet.CommitChangesAsync();
+
+                korm.Query<Person>()
+                    .Should()
+                    .NotContain(p => p.Id == 1);
+            }
+        }
+
         private void DeleteDataCore()
         {
             using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
@@ -340,7 +356,7 @@ INSERT INTO [{Table_LimitOffsetTest}] VALUES (20, 'twenty');";
 
                 dbSet.CommitChanges();
 
-                korm.Query<Person>().Count().Should().Be(0);
+                korm.Query<Person>().Should().BeEmpty();
             }
         }
 

--- a/tests/Kros.KORM.UnitTests/Integration/IDatabaseExtensionsShould.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/IDatabaseExtensionsShould.cs
@@ -1,0 +1,153 @@
+﻿using FluentAssertions;
+using Kros.KORM.Metadata;
+using Kros.KORM.Metadata.Attribute;
+using Kros.KORM.UnitTests.Base;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kros.KORM.UnitTests.Integration
+{
+    public class IDatabaseExtensionsShould : DatabaseTestBase
+    {
+        #region Nested Classes
+
+        [Alias("People")]
+        private class Person
+        {
+            [Key(AutoIncrementMethodType.Custom)]
+            public int Id { get; set; }
+
+            public int Age { get; set; }
+
+            public string FirstName { get; set; }
+
+            public string LastName { get; set; }
+        }
+
+        #endregion
+
+        #region SQL Scripts
+
+        private const string Table_TestTable = "People";
+
+        private static readonly string CreateTable_TestTable =
+$@"CREATE TABLE [dbo].[{Table_TestTable}] (
+    [Id] [int] NOT NULL,
+    [Age] [int] NULL,
+    [FirstName] [nvarchar](50) NULL,
+    [LastName] [nvarchar](50) NULL
+) ON [PRIMARY];";
+
+        private static readonly string InsertDataScript =
+$@"INSERT INTO {Table_TestTable} VALUES (1, 18, 'John', 'Smith');
+INSERT INTO {Table_TestTable} VALUES (2, 22, 'Kilie', 'Bistrol');";
+
+        #endregion
+
+        [Fact]
+        public async Task AddEntityAsync()
+        {
+            using (IDatabase database = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var person = new Person() { Id = 3, Age = 18, FirstName = "Bob", LastName = "Bobek" };
+
+                await database.AddAsync(person);
+
+                database.Query<Person>()
+                    .FirstOrDefault(p => p.Id == 3)
+                    .Should()
+                    .BeEquivalentTo(person);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteEntityAsync()
+        {
+            using (IDatabase database = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var person = new Person() { Id = 2};
+
+                await database.DeleteAsync(person);
+
+                database.Query<Person>()
+                    .Should()
+                    .NotContain(p=> p.Id == 2);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteEntityByIdAsync()
+        {
+            using (IDatabase database = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                await database.DeleteAsync<Person>(2);
+
+                database.Query<Person>()
+                    .Should()
+                    .NotContain(p => p.Id == 2);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteEntityByLinqConditionAsync()
+        {
+            using (IDatabase database = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                await database.DeleteAsync<Person>(p=> p.Id == 2);
+
+                database.Query<Person>()
+                    .Should()
+                    .NotContain(p => p.Id == 2);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteEntityByConditionAsync()
+        {
+            using (IDatabase database = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                await database.DeleteAsync<Person>("Id = @1", 2);
+
+                database.Query<Person>()
+                    .Should()
+                    .NotContain(p => p.Id == 2);
+            }
+        }
+
+        [Fact]
+        public async Task EditEntityAsync()
+        {
+            using (IDatabase database = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var person = new Person() { Id = 2, Age = 18, FirstName = "Bob", LastName = "Bobek" };
+
+                await database.EditAsync(person);
+
+                database.Query<Person>()
+                    .FirstOrDefault(p => p.Id == 2)
+                    .Should()
+                    .BeEquivalentTo(person);
+            }
+        }
+
+        [Fact]
+        public async Task EditEntityWithSpecificColumnAsync()
+        {
+            using (IDatabase database = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var person = new Person() { Id = 2, Age = 18, FirstName = "Bob", LastName = "Bobek" };
+
+                await database.EditAsync(person, "Id", "Age");
+
+                Person actual = database
+                    .Query<Person>()
+                    .FirstOrDefault(p => p.Id == 2);
+
+                actual.Age.Should().Be(18);
+                actual.FirstName.Should().Be("Kilie");
+                actual.LastName.Should().Be("Bistrol");
+            }
+        }
+    }
+}

--- a/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
@@ -277,10 +277,11 @@ namespace Kros.KORM.UnitTests
                 }
             }, new List<PropertyInfo>(), null);
 
-            var dbSet = new DbSet<Person>(Substitute.For<ICommandGenerator<Person>>(),
-                                         Substitute.For<IQueryProvider>(),
-                                         Substitute.For<IQuery<Person>>(),
-                                         tableInfo);
+            var dbSet = new DbSet<Person>(
+                Substitute.For<ICommandGenerator<Person>>(),
+                Substitute.For<IQueryProvider>(),
+                Substitute.For<IQuery<Person>>(),
+                tableInfo);
 
             Action action = () =>
             {
@@ -294,7 +295,7 @@ namespace Kros.KORM.UnitTests
             {
                 action.Should()
                     .Throw<ArgumentException>()
-                    .WithMessage("*'Int32'*");
+                    .WithMessage("*System.Int32*");
             }
             else
             {

--- a/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
@@ -263,6 +263,45 @@ namespace Kros.KORM.UnitTests
                 .WithMessage("*FakeProvider*Person*");
         }
 
+        [Theory]
+        [MemberData(nameof(GetDataForDeleteByIds))]
+        public void ThrowExceptionWhenTryDeleteByIdsWithIncorrectType(IEnumerable<object> ids, bool throwException)
+        {
+            var tableInfo = new TableInfo(new List<ColumnInfo>()
+            {
+                new ColumnInfo(){
+                    Name = "Id",
+                    IsPrimaryKey = true,
+                    PropertyInfo = typeof(Person).GetProperty(nameof(Person.Id))
+                }
+            }, new List<PropertyInfo>(), null);
+
+            var dbSet = new DbSet<Person>(Substitute.For<ICommandGenerator<Person>>(),
+                                         Substitute.For<IQueryProvider>(),
+                                         Substitute.For<IQuery<Person>>(),
+                                         tableInfo);
+
+            Action action = () => dbSet.Delete(ids);
+
+            if (throwException)
+            {
+                action.Should()
+                    .Throw<ArgumentException>()
+                    .WithMessage("*'Int32'*");
+            }
+            else
+            {
+                action.Should().NotThrow();
+            }
+        }
+
+        public static IEnumerable<object[]> GetDataForDeleteByIds()
+        {
+            yield return new object[] { new List<object>() { "1", 1 }, true };
+            yield return new object[] { new List<object>() { 1, 2, 3, true }, true };
+            yield return new object[] { new List<object>() { 1, 2, 3, 4 }, false};
+        }
+
         #endregion
 
         #region Test classes

--- a/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
@@ -6,6 +6,7 @@ using Kros.KORM.Data;
 using Kros.KORM.Exceptions;
 using Kros.KORM.Metadata;
 using Kros.KORM.Query;
+using Kros.KORM.Query.Sql;
 using NSubstitute;
 using System;
 using System.Collections.Generic;
@@ -445,6 +446,11 @@ namespace Kros.KORM.UnitTests
             }
 
             public Task<object> ExecuteScalarCommandAsync(DbCommand command)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ISqlExpressionVisitor GetExpressionVisitor()
             {
                 throw new NotImplementedException();
             }

--- a/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
@@ -282,7 +282,13 @@ namespace Kros.KORM.UnitTests
                                          Substitute.For<IQuery<Person>>(),
                                          tableInfo);
 
-            Action action = () => dbSet.Delete(ids);
+            Action action = () =>
+            {
+                foreach (object id in ids)
+                {
+                    dbSet.Delete(id);
+                }
+            };
 
             if (throwException)
             {
@@ -300,7 +306,7 @@ namespace Kros.KORM.UnitTests
         {
             yield return new object[] { new List<object>() { "1", 1 }, true };
             yield return new object[] { new List<object>() { 1, 2, 3, true }, true };
-            yield return new object[] { new List<object>() { 1, 2, 3, 4 }, false};
+            yield return new object[] { new List<object>() { 1, 2, 3, 4 }, false };
         }
 
         #endregion

--- a/tests/Kros.KORM.UnitTests/Query/Sql/DefaultQuerySqlGeneratorShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Sql/DefaultQuerySqlGeneratorShould.cs
@@ -1,9 +1,11 @@
-﻿using FluentAssertions;
+﻿using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
+using FluentAssertions;
 using Kros.KORM.Metadata;
 using Kros.KORM.Metadata.Attribute;
 using Kros.KORM.Query.Expressions;
 using Kros.KORM.Query.Sql;
 using System;
+using System.Linq.Expressions;
 using Xunit;
 
 namespace Kros.KORM.UnitTests.Query.Sql
@@ -107,6 +109,18 @@ namespace Kros.KORM.UnitTests.Query.Sql
             var queryInfo = generator.GenerateSql(expression);
 
             queryInfo.Query.Should().Be(@"SELECT LastName, Min(Age) FROM TPerson GROUP BY LastName");
+        }
+
+        [Fact]
+        public void GenerateWhereCondition()
+        {
+            DefaultQuerySqlGenerator generator = CreateQuerySqlGenerator();
+            Expression<Func<Person, bool>> where = (p) => p.Id == 1 && p.FirstName.StartsWith("M");
+
+            WhereExpression whereExpression = generator.GenerateWhereCondition(where);
+
+            whereExpression.Sql.Should().Be("((Id = @1) AND (Name LIKE @2 + '%'))");
+            whereExpression.Parameters.Should().BeEquivalentTo(new object[] { 1, "M" });
         }
 
         private static DefaultQuerySqlGenerator CreateQuerySqlGenerator()

--- a/tests/Kros.KORM.UnitTests/Query/Sql/DefaultQuerySqlGeneratorShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Sql/DefaultQuerySqlGeneratorShould.cs
@@ -1,5 +1,4 @@
-﻿using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Kros.KORM.Metadata;
 using Kros.KORM.Metadata.Attribute;
 using Kros.KORM.Query.Expressions;

--- a/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorTestBase.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Sql/LinqTranslatorTestBase.cs
@@ -295,6 +295,11 @@ namespace Kros.KORM.UnitTests.Query.Sql
                 throw new NotImplementedException();
             }
 
+            public ISqlExpressionVisitor GetExpressionVisitor()
+            {
+                throw new NotImplementedException();
+            }
+
             public void SetParameterDbType(DbParameter parameter, string tableName, string columnName)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
Closes #37 
This PR add support for deleting items by ids and conditions.

----

### `DbSet` has new methods:

```CSharp
void Delete(object id);
void Delete(Expression<Func<TEntity, bool>> condition);
void Delete(string condition, params object[] parameters);
```

- I don't add overload with `IEnumerable ids` because this has colision with `object id`.
- `DbSet` has properties like `AddedItems`, `EditedItems`, `DeletedItems`. I decided not to add property to these new methods. It doesn't make sense to me.

### `IDatabaseExtensions`

I created the new `IDatabaseExtensions` class. This class contains extensions for easier calling methods like `Add`, `Edit`, `Delete`.

```CSharp
await database.AddAsync(person);
await database.DeleteAsync(person);
await database.DeleteAsync<Person>(2);
await database.DeleteAsync<Person>(p=> p.Id == 2);
await database.DeleteAsync<Person>("Id = @1", 2);
await database.EditAsync(person);
await database.EditAsync(person, "Id", "Age");

```

----

When you check this PR I will write the documentation into the readme.