### PR TITLE
Simple boolean LINQ conditions, delete using variable does not throw NotSupportedException

### DIFF
--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -169,6 +169,15 @@ namespace Kros.KORM.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot get value of constant expression &quot;{0}&quot;..
+        /// </summary>
+        internal static string Error_CannotGetValueOfConstantExpression {
+            get {
+                return ResourceManager.GetString("Error_CannotGetValueOfConstantExpression", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Connection string is not set..
         /// </summary>
         internal static string Error_ConnectionStringNotSet {

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -154,6 +154,10 @@
   </data>
   <data name="ConverterTypeIsNotIConverter" xml:space="preserve">
     <value>Converter type must implement implement IConverter interface.</value>
+  </data>
+  <data name="Error_CannotGetValueOfConstantExpression" xml:space="preserve">
+    <value>Cannot get value of constant expression "{0}".</value>
+    <comment>0 - expression</comment>
   </data>
   <data name="Error_ConnectionStringNotSet" xml:space="preserve">
     <value>Connection string is not set.</value>

--- a/tests/Kros.KORM.UnitTests/Integration/DbSetShould.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/DbSetShould.cs
@@ -266,6 +266,29 @@ INSERT INTO [{Table_LimitOffsetTest}] VALUES (20, 'twenty');";
 
         #region Delete Data
 
+        private class DeleteItem
+        {
+            public int Value { get; set; }
+            public int GetId() => 1;
+            public DeleteSubItem Sub1 { get; } = new DeleteSubItem();
+        }
+
+        private class DeleteSubItem
+        {
+            public DeleteSubSubItem Sub2 { get; } = new DeleteSubSubItem();
+        }
+
+        private class DeleteSubSubItem
+        {
+            public int Value { get; set; }
+            public int GetId() => 1;
+            public int GetId(int value1, int value2) => value1 + value2;
+        }
+
+        private int DeleteGetId() => 1;
+
+        private int DeleteGetId(int p1, int p2) => p1 + p2;
+
         [Fact]
         public void DeleteData()
         {
@@ -314,6 +337,23 @@ INSERT INTO [{Table_LimitOffsetTest}] VALUES (20, 'twenty');";
         }
 
         [Fact]
+        public async Task DeleteDataByIdUsingVariableAsync()
+        {
+            using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var dbSet = korm.Query<Person>().AsDbSet();
+                int tmp = 1;
+                dbSet.Delete(tmp);
+
+                await dbSet.CommitChangesAsync();
+
+                korm.Query<Person>()
+                    .Should()
+                    .NotContain(p => p.Id == 1);
+            }
+        }
+
+        [Fact]
         public async Task DeleteDataByIdsAsync()
         {
             using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
@@ -335,6 +375,111 @@ INSERT INTO [{Table_LimitOffsetTest}] VALUES (20, 'twenty');";
             {
                 var dbSet = korm.Query<Person>().AsDbSet();
                 dbSet.Delete(p => p.Id == 1);
+
+                await dbSet.CommitChangesAsync();
+
+                korm.Query<Person>()
+                    .Should()
+                    .NotContain(p => p.Id == 1);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteDataByLinqConditionUsingVariableAsync()
+        {
+            using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var dbSet = korm.Query<Person>().AsDbSet();
+                int tmp = 1;
+                dbSet.Delete(p => p.Id == tmp);
+
+                await dbSet.CommitChangesAsync();
+
+                korm.Query<Person>()
+                    .Should()
+                    .NotContain(p => p.Id == 1);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteDataByLinqConditionUsingPropertyAsync()
+        {
+            using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var dbSet = korm.Query<Person>().AsDbSet();
+                var item = new DeleteItem
+                {
+                    Value = 1
+                };
+                dbSet.Delete(p => p.Id == item.Value);
+
+                await dbSet.CommitChangesAsync();
+
+                korm.Query<Person>()
+                    .Should()
+                    .NotContain(p => p.Id == 1);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteDataByLinqConditionUsingNestedPropertyAsync()
+        {
+            using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var dbSet = korm.Query<Person>().AsDbSet();
+                var item = new DeleteItem();
+                item.Sub1.Sub2.Value = 1;
+                dbSet.Delete(p => p.Id == item.Sub1.Sub2.Value);
+
+                await dbSet.CommitChangesAsync();
+
+                korm.Query<Person>()
+                    .Should()
+                    .NotContain(p => p.Id == 1);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteDataByLinqConditionUsingMethodAsync()
+        {
+            using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var dbSet = korm.Query<Person>().AsDbSet();
+                dbSet.Delete(p => p.Id == DeleteGetId(0, DeleteGetId()));
+
+                await dbSet.CommitChangesAsync();
+
+                korm.Query<Person>()
+                    .Should()
+                    .NotContain(p => p.Id == 1);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteDataByLinqConditionUsingMethodInAnotherClassAsync()
+        {
+            using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var dbSet = korm.Query<Person>().AsDbSet();
+                var item = new DeleteItem();
+                dbSet.Delete(p => p.Id == item.GetId());
+
+                await dbSet.CommitChangesAsync();
+
+                korm.Query<Person>()
+                    .Should()
+                    .NotContain(p => p.Id == 1);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteDataByLinqConditionUsingSubMethodInAnotherClassAsync()
+        {
+            using (var korm = CreateDatabase(CreateTable_TestTable, InsertDataScript))
+            {
+                var dbSet = korm.Query<Person>().AsDbSet();
+                var item = new DeleteItem();
+                dbSet.Delete(p => p.Id == item.Sub1.Sub2.GetId(0, item.Sub1.Sub2.GetId()));
 
                 await dbSet.CommitChangesAsync();
 


### PR DESCRIPTION
Closes #43 

- Condition for `DbSet.Delete(...)` now works with variables, methods and properties of another object.
- Boolean conditions can be written in simpler way. We can write:
  - `item => item.IsDeleted` instead of `item => item.IsDeleted == true`
  - `item => !item.IsDeleted` instead of `item => item.IsDeleted == false`