### PR TITLE
Database extensions for manipulating multiple entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,12 +630,17 @@ For simplifying calling methods (`Add`, `Edit`, `Delete`) use extension methods 
 
 ```CSharp
 await database.AddAsync(person);
+await database.AddAsync(people);
+await database.BulkAddAsync(people);
 await database.DeleteAsync(person);
+await database.DeleteAsync(people);
 await database.DeleteAsync<Person>(2);
 await database.DeleteAsync<Person>(p => p.Id == 2);
 await database.DeleteAsync<Person>("Id = @1", 2);
 await database.EditAsync(person);
 await database.EditAsync(person, "Id", "Age");
+await database.EditAsync(people);
+await database.BulkEditAsync(people);
 ```
 
 ### SQL commands executing

--- a/src/IDatabaseExtensions.cs
+++ b/src/IDatabaseExtensions.cs
@@ -36,7 +36,7 @@ namespace Kros.KORM
         /// <typeparam name="TEntity">Entities type.</typeparam>
         /// <param name="database"><see cref="IDatabase"/> instance.</param>
         /// <param name="entities">Entities to add.</param>
-        public static async Task AddBulkAsync<TEntity>(
+        public static async Task BulkAddAsync<TEntity>(
             this IDatabase database,
             IEnumerable<TEntity> entities) where TEntity : class
             => await ProcessBulkOperationAsync(database, async (IDbSet<TEntity> dbSet) => await dbSet.BulkInsertAsync(entities));
@@ -118,7 +118,7 @@ namespace Kros.KORM
         /// <typeparam name="TEntity">Entities type.</typeparam>
         /// <param name="database"><see cref="IDatabase"/> instance.</param>
         /// <param name="entities">Entities to edit.</param>
-        public static async Task EditBulkAsync<TEntity>(
+        public static async Task BulkEditAsync<TEntity>(
             this IDatabase database,
             IEnumerable<TEntity> entities) where TEntity : class
             => await ProcessBulkOperationAsync(database, async (IDbSet<TEntity> dbSet) => await dbSet.BulkUpdateAsync(entities));

--- a/src/IDatabaseExtensions.cs
+++ b/src/IDatabaseExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Kros.KORM.Query;
 using Kros.KORM.Query.Sql;
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 
@@ -21,6 +22,26 @@ namespace Kros.KORM
             => await CommitChangesAsync(database, (IDbSet<TEntity> dbSet) => dbSet.Add(entity));
 
         /// <summary>
+        /// Adds <paramref name="entities"/> to the database.
+        /// </summary>
+        /// <typeparam name="TEntity">Entities type.</typeparam>
+        /// <param name="database"><see cref="IDatabase"/> instance.</param>
+        /// <param name="entities">Entities to add.</param>
+        public static async Task AddAsync<TEntity>(this IDatabase database, IEnumerable<TEntity> entities) where TEntity : class
+            => await CommitChangesAsync(database, (IDbSet<TEntity> dbSet) => dbSet.Add(entities));
+
+        /// <summary>
+        /// Adds <paramref name="entities"/> to the database via bulk insert.
+        /// </summary>
+        /// <typeparam name="TEntity">Entities type.</typeparam>
+        /// <param name="database"><see cref="IDatabase"/> instance.</param>
+        /// <param name="entities">Entities to add.</param>
+        public static async Task AddBulkAsync<TEntity>(
+            this IDatabase database,
+            IEnumerable<TEntity> entities) where TEntity : class
+            => await ProcessBulkOperationAsync(database, async (IDbSet<TEntity> dbSet) => await dbSet.BulkInsertAsync(entities));
+
+        /// <summary>
         /// Deletes the <paramref name="entity"/> from the database.
         /// </summary>
         /// <typeparam name="TEntity">Entity type.</typeparam>
@@ -28,6 +49,17 @@ namespace Kros.KORM
         /// <param name="entity">The entity to delete.</param>
         public static async Task DeleteAsync<TEntity>(this IDatabase database, TEntity entity) where TEntity : class
             => await CommitChangesAsync(database, (IDbSet<TEntity> dbSet) => dbSet.Delete(entity));
+
+        /// <summary>
+        /// Deletes <paramref name="entities"/> from the database.
+        /// </summary>
+        /// <typeparam name="TEntity">Entities type.</typeparam>
+        /// <param name="database"><see cref="IDatabase"/> instance.</param>
+        /// <param name="entities">Entities to delete.</param>
+        public static async Task DeleteAsync<TEntity>(
+            this IDatabase database,
+            IEnumerable<TEntity> entities) where TEntity : class
+            => await CommitChangesAsync(database, (IDbSet<TEntity> dbSet) => dbSet.Delete(entities));
 
         /// <summary>
         /// Deletes the <typeparamref name="TEntity"/> with <paramref name="id"/> from the database.
@@ -72,6 +104,26 @@ namespace Kros.KORM
             => await CommitChangesAsync(database, (IDbSet<TEntity> dbSet) => dbSet.Edit(entity));
 
         /// <summary>
+        /// Edits <paramref name="entities"/> in the database.
+        /// </summary>
+        /// <typeparam name="TEntity">Entities type.</typeparam>
+        /// <param name="database"><see cref="IDatabase"/> instance.</param>
+        /// <param name="entities">Entities to edit.</param>
+        public static async Task EditAsync<TEntity>(this IDatabase database, IEnumerable<TEntity> entities) where TEntity : class
+            => await CommitChangesAsync(database, (IDbSet<TEntity> dbSet) => dbSet.Edit(entities));
+
+        /// <summary>
+        /// Edits <paramref name="entities"/> in the database via bulk update.
+        /// </summary>
+        /// <typeparam name="TEntity">Entities type.</typeparam>
+        /// <param name="database"><see cref="IDatabase"/> instance.</param>
+        /// <param name="entities">Entities to edit.</param>
+        public static async Task EditBulkAsync<TEntity>(
+            this IDatabase database,
+            IEnumerable<TEntity> entities) where TEntity : class
+            => await ProcessBulkOperationAsync(database, async (IDbSet<TEntity> dbSet) => await dbSet.BulkUpdateAsync(entities));
+
+        /// <summary>
         /// Edits the <paramref name="entity"/> in the database.
         /// </summary>
         /// <typeparam name="TEntity">Entity type.</typeparam>
@@ -84,18 +136,30 @@ namespace Kros.KORM
             params string[] columns) where TEntity : class
             => await CommitChangesAsync(database, (IDbSet<TEntity> dbSet) => dbSet.Edit(entity), columns);
 
+        private static IDbSet<TEntity> GetDbSet<TEntity>(IDatabase database, params string[] columns) where TEntity : class
+            => columns.Length == 0
+                ? database.Query<TEntity>().AsDbSet()
+                : database.Query<TEntity>().Select(columns).AsDbSet();
+
         private static async Task CommitChangesAsync<TEntity>(
             IDatabase database,
             Action<IDbSet<TEntity>> action,
             params string[] columns) where TEntity : class
         {
-            IDbSet<TEntity> dbSet = columns.Length == 0
-                ? database.Query<TEntity>().AsDbSet()
-                : database.Query<TEntity>().Select(columns).AsDbSet();
+            IDbSet<TEntity> dbSet = GetDbSet<TEntity>(database, columns);
 
             action(dbSet);
 
             await dbSet.CommitChangesAsync();
+        }
+
+        private static async Task ProcessBulkOperationAsync<TEntity>(
+            IDatabase database,
+            Func<IDbSet<TEntity>, Task> action,
+            params string[] columns) where TEntity : class
+        {
+            IDbSet<TEntity> dbSet = GetDbSet<TEntity>(database, columns);
+            await action(dbSet);
         }
     }
 }


### PR DESCRIPTION
Added support for insert/update/delete of IEnumerable of entities and bulk insert/update of IEnumerable of entities to `IDatabaseExtensions`.

Closes #50.