### PR TITLE
WIP: Make QueryProvider.Connection virtual

### DIFF
--- a/src/Data/ConnectionHelper.cs
+++ b/src/Data/ConnectionHelper.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Text;
 
 namespace Kros.KORM.Data
 {
@@ -45,9 +43,6 @@ namespace Kros.KORM.Data
             }
         }
 
-        public void Dispose()
-        {
-            Dispose(true);
-        }
+        public void Dispose() => Dispose(true);
     }
 }

--- a/src/Data/TransactionHelper.cs
+++ b/src/Data/TransactionHelper.cs
@@ -1,4 +1,5 @@
-﻿using Kros.Utils;
+﻿using Kros.KORM.Properties;
+using Kros.Utils;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -19,7 +20,6 @@ namespace Kros.KORM.Data
 
         private class Transaction : ITransaction
         {
-            private readonly TransactionHelper _transactionHelper;
             private readonly DbConnection _connection;
             private readonly bool _closeConnection;
             private readonly Lazy<DbTransaction> _transaction;

--- a/src/Database.cs
+++ b/src/Database.cs
@@ -60,7 +60,13 @@ namespace Kros.KORM
         /// <summary>
         /// Builder for creating <see cref="IDatabase"/> instance.
         /// </summary>
+        [Obsolete("Use CreateBuilder method.")]
         public static IDatabaseBuilder Builder => new DatabaseBuilder();
+
+        /// <summary>
+        /// Creates a builder for creating <see cref="IDatabase"/> instance.
+        /// </summary>
+        public static IDatabaseBuilder CreateBuilder() => new DatabaseBuilder();
 
         #endregion
 

--- a/src/IAuthTokenProvider.cs
+++ b/src/IAuthTokenProvider.cs
@@ -1,0 +1,14 @@
+﻿namespace Kros.KORM
+{
+    /// <summary>
+    /// Support for token-based authentication for SQL Server.
+    /// </summary>
+    public interface IAuthTokenProvider
+    {
+        /// <summary>
+        /// Returns authentication token, or <see langword="null" /> value, if token can not be obtained.
+        /// </summary>
+        /// <returns>Authentication token.</returns>
+        string GetToken();
+    }
+}

--- a/src/Query/Providers/QueryProvider.cs
+++ b/src/Query/Providers/QueryProvider.cs
@@ -631,7 +631,7 @@ namespace Kros.KORM.Query
         /// Vráti spojenie na databázu s ktorou trieda pracuje. Ak trieda bola vytvorená iba so zadaným
         /// connection string-om, je vytvorené nové spojenie.
         /// </summary>
-        protected DbConnection Connection
+        protected virtual DbConnection Connection
         {
             get
             {

--- a/src/Query/Providers/SqlServerQueryProvider.cs
+++ b/src/Query/Providers/SqlServerQueryProvider.cs
@@ -17,6 +17,8 @@ namespace Kros.KORM.Query
     /// <seealso cref="Kros.KORM.Query.QueryProvider" />
     public class SqlServerQueryProvider : QueryProvider
     {
+        private readonly IAuthTokenProvider _tokenProvider;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlServerQueryProvider"/> class.
         /// </summary>
@@ -25,14 +27,17 @@ namespace Kros.KORM.Query
         /// <param name="modelBuilder">The model builder.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="databaseMapper">The Database mapper.</param>
+        /// <param name="tokenProvider">Provider to support token-based authentication.</param>
         public SqlServerQueryProvider(
             KormConnectionSettings connectionString,
             ISqlExpressionVisitorFactory sqlGeneratorFactory,
             IModelBuilder modelBuilder,
             ILogger logger,
-            IDatabaseMapper databaseMapper)
+            IDatabaseMapper databaseMapper,
+            IAuthTokenProvider tokenProvider)
             : base(connectionString, sqlGeneratorFactory, modelBuilder, logger, databaseMapper)
         {
+            _tokenProvider = tokenProvider;
         }
 
         /// <summary>
@@ -43,20 +48,43 @@ namespace Kros.KORM.Query
         /// <param name="modelBuilder">The model builder.</param>
         /// <param name="logger">The logger.</param>
         /// <param name="databaseMapper">The Database mapper.</param>
+        /// <param name="tokenProvider">Provider to support token-based authentication.</param>
         public SqlServerQueryProvider(
             DbConnection connection,
             ISqlExpressionVisitorFactory sqlGeneratorFactory,
             IModelBuilder modelBuilder,
             ILogger logger,
-            IDatabaseMapper databaseMapper)
+            IDatabaseMapper databaseMapper,
+            IAuthTokenProvider tokenProvider)
             : base(connection, sqlGeneratorFactory, modelBuilder, logger, databaseMapper)
         {
+            _tokenProvider = tokenProvider;
         }
 
         /// <summary>
         /// Returns <see cref="DbProviderFactory"/> for current provider.
         /// </summary>
         public override DbProviderFactory DbProviderFactory => SqlClientFactory.Instance;
+
+        /// <summary>
+        /// Returns (creates if needed) connection. If <see cref="IAuthTokenProvider"/> was setup in constructor,
+        /// it is used to set the <see cref="SqlConnection.AccessToken">AccessToken</see> on connection.
+        /// </summary>
+        /// <returns><see cref="DbConnection"/> instance.</returns>
+        protected override DbConnection GetConnection()
+        {
+            var connection = (SqlConnection)base.GetConnection();
+            SetAccessToken(connection);
+            return connection;
+        }
+
+        private void SetAccessToken(SqlConnection connection)
+        {
+            if (_tokenProvider != null)
+            {
+                connection.AccessToken = _tokenProvider.GetToken();
+            }
+        }
 
         /// <summary>
         /// Creates instance of <see cref="IBulkInsert" />.
@@ -69,11 +97,11 @@ namespace Kros.KORM.Query
             var transaction = GetCurrentTransaction();
             if (IsExternalConnection || transaction != null)
             {
-                return new SqlServerBulkInsert(Connection as SqlConnection, transaction as SqlTransaction);
+                return new SqlServerBulkInsert(GetConnection() as SqlConnection, transaction as SqlTransaction);
             }
             else
             {
-                return new SqlServerBulkInsert(ConnectionString);
+                return new SqlServerBulkInsert(CreateConnection());
             }
         }
 
@@ -89,12 +117,20 @@ namespace Kros.KORM.Query
 
             if (IsExternalConnection || transaction != null)
             {
-                return new SqlServerBulkUpdate(Connection as SqlConnection, transaction as SqlTransaction);
+                return new SqlServerBulkUpdate(GetConnection() as SqlConnection, transaction as SqlTransaction);
             }
             else
             {
-                return new SqlServerBulkUpdate(ConnectionString);
+                return new SqlServerBulkUpdate(CreateConnection());
             }
+        }
+
+        private SqlConnection CreateConnection()
+        {
+            var connection = (SqlConnection)DbProviderFactory.CreateConnection();
+            connection.ConnectionString = ConnectionString;
+            SetAccessToken(connection);
+            return connection;
         }
 
         /// <summary>

--- a/src/Query/Providers/SqlServerQueryProviderFactory.cs
+++ b/src/Query/Providers/SqlServerQueryProviderFactory.cs
@@ -27,7 +27,8 @@ namespace Kros.KORM.Query
                 new SqlServerSqlExpressionVisitorFactory(databaseMapper),
                 modelBuilder,
                 new Logger(),
-                databaseMapper);
+                databaseMapper,
+                null);
 
         /// <summary>
         /// Creates the SqlServer query provider.
@@ -47,7 +48,8 @@ namespace Kros.KORM.Query
                 new SqlServerSqlExpressionVisitorFactory(databaseMapper),
                 modelBuilder,
                 new Logger(),
-                databaseMapper);
+                databaseMapper,
+                null);
 
         /// <summary>
         /// Registers instance of this type to <see cref="QueryProviderFactories"/>.

--- a/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
+++ b/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
@@ -284,7 +284,8 @@ SELECT * FROM @OutputTable;";
                     new SqlServerSqlExpressionVisitorFactory(new DatabaseMapper(new ConventionModelMapper())),
                     Substitute.For<IModelBuilder>(),
                     new Logger(),
-                    Substitute.For<IDatabaseMapper>()));
+                    Substitute.For<IDatabaseMapper>(),
+                    null));
 
             return query;
         }
@@ -349,7 +350,8 @@ SELECT * FROM @OutputTable;";
                     new SqlServerSqlExpressionVisitorFactory(new DatabaseMapper(new ConventionModelMapper())),
                     Substitute.For<IModelBuilder>(),
                     new Logger(),
-                    Substitute.For<IDatabaseMapper>()));
+                    Substitute.For<IDatabaseMapper>(),
+                    null));
 
             return query;
         }

--- a/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Providers/QueryProviderShould.cs
@@ -76,10 +76,7 @@ namespace Kros.KORM.UnitTests.Query.Providers
 
             public override DbProviderFactory DbProviderFactory => _dbProviderFactory;
 
-            public void CreateConnection()
-            {
-                var connection = Connection;
-            }
+            public void CreateConnection() => GetConnection();
 
             public override IBulkInsert CreateBulkInsert()
             {
@@ -511,7 +508,8 @@ END";
                 Substitute.For<ISqlExpressionVisitorFactory>(),
                 new ModelBuilder(Database.DefaultModelFactory),
                 Substitute.For<ILogger>(),
-                Substitute.For<IDatabaseMapper>());
+                Substitute.For<IDatabaseMapper>(),
+                null);
 
         private static SqlServerQueryProvider CreateQueryProvider(string connectionString)
             => new SqlServerQueryProvider(
@@ -519,7 +517,8 @@ END";
                 Substitute.For<ISqlExpressionVisitorFactory>(),
                 new ModelBuilder(Database.DefaultModelFactory),
                 Substitute.For<ILogger>(),
-                Substitute.For<IDatabaseMapper>());
+                Substitute.For<IDatabaseMapper>(),
+                null);
 
         #endregion
     }

--- a/tests/Kros.KORM.UnitTests/Query/QueryShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/QueryShould.cs
@@ -272,7 +272,8 @@ namespace Kros.KORM.UnitTests.Query
                     new SqlServerSqlExpressionVisitorFactory(mapper),
                     Substitute.For<IModelBuilder>(),
                     new Logger(),
-                    Substitute.For<IDatabaseMapper>()));
+                    Substitute.For<IDatabaseMapper>(),
+                    null));
 
             return query;
         }


### PR DESCRIPTION
We need `Connection` property virtual so we can set its `AccessToken` in inherited classes.