### PR TITLE
Record type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -319,3 +319,4 @@ Kros.KORM/tests/Kros.KORM.PerformanceTests/TestRunnerScript.ps1
 /Documentattion/_site
 /Documentattion/api
 appsettings.local.json
+tests/Kros.KORM.PerformanceTests/BenchmarkDotNet.Artifacts

--- a/Kros.KORM.sln
+++ b/Kros.KORM.sln
@@ -18,6 +18,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build.yml = build.yml
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kros.KORM.PerformanceTests", "tests\Kros.KORM.PerformanceTests\Kros.KORM.PerformanceTests.csproj", "{7DAE1DC7-4C58-41B5-AC88-86933E26095D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,6 +38,10 @@ Global
 		{67731885-451B-42E2-BD2F-F885AC44432F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{67731885-451B-42E2-BD2F-F885AC44432F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{67731885-451B-42E2-BD2F-F885AC44432F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7DAE1DC7-4C58-41B5-AC88-86933E26095D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7DAE1DC7-4C58-41B5-AC88-86933E26095D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7DAE1DC7-4C58-41B5-AC88-86933E26095D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7DAE1DC7-4C58-41B5-AC88-86933E26095D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -43,6 +49,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{5384F70F-75DD-4BE1-84B3-3DD4681BB622} = {F98075A9-AFBF-42A6-BF99-070F54BBA3EA}
 		{67731885-451B-42E2-BD2F-F885AC44432F} = {F98075A9-AFBF-42A6-BF99-070F54BBA3EA}
+		{7DAE1DC7-4C58-41B5-AC88-86933E26095D} = {F98075A9-AFBF-42A6-BF99-070F54BBA3EA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {62686C83-FD22-48A7-B4B2-F4981D81D79E}

--- a/Kros.KORM.sln
+++ b/Kros.KORM.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		build-and-test.yml = build-and-test.yml
 		build-ci.yml = build-ci.yml
 		build.yml = build.yml
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kros.KORM.PerformanceTests", "tests\Kros.KORM.PerformanceTests\Kros.KORM.PerformanceTests.csproj", "{7DAE1DC7-4C58-41B5-AC88-86933E26095D}"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To contribute with new topics/information or make changes, see [contributing](ht
 * [Model builder](#model-builder)
 * [Committing of changes](#committing-of-changes)
 * [SQL commands executing](#sql-commands-executing)
+* [Record types](#record-types)
 * [Logging](#logging)
 * [Supported database types](#supported-database-types)
 * [ASP.NET Core extensions](#aspnet-core-extensions)
@@ -757,6 +758,38 @@ using (var transaction = database.BeginTransaction(IsolationLevel.Chaos))
     }
 }
 ```
+
+### Record types
+
+KORM supports a new `record` type for model definition.
+
+```csharp
+public record Person(int Id, string FirstName, string LastName);
+
+using var database = new Database(new SqlConnection("connection string"));
+
+foreach (Person person = database.Query<Person>())
+{
+    Console.WriteLine($"{person.Id}: {person.FirstName} - {person.LastName}");
+}
+```
+
+The same features as for "standard" `class`-es are supported. Converters, name mapping and value injection. It is possible to use [fluent notation](#Configure-model-mapping-by-fluent-api), but also using attributes.
+
+To use attribute notation, you must use syntax with `property:` keyword.
+
+```csharp
+public record Person(int Id, [property: Alias("FirstName")]string Name);
+```
+
+Materializing `record` types is a bit faster than with property-filled classes.
+
+1000 rows of `InMemoryDbReader`:
+
+| Method | Mean | Error | StdDev |
+|----|----|----|----|
+|RecordTypes|301.5 us | 5.07 us | 7.11 us|
+|ClassTypes|458.1 us | 7.13 us | 6.68 us|
 
 ### Logging
 

--- a/README.md
+++ b/README.md
@@ -786,10 +786,10 @@ Materializing `record` types is a bit faster than with property-filled classes.
 
 1000 rows of `InMemoryDbReader`:
 
-| Method | Mean | Error | StdDev |
-|----|----|----|----|
-|RecordTypes|301.5 us | 5.07 us | 7.11 us|
-|ClassTypes|458.1 us | 7.13 us | 6.68 us|
+| Method      | Mean      | Error   | StdDev  |
+| ----------- | --------- | ------- | ------- |
+| RecordTypes | 301.50 μs | 5.07 μs | 7.11 μs |
+| ClassTypes  | 458.10 μs | 7.13 μs | 6.68 μs |
 
 ### Logging
 

--- a/src/Converter/TypeConverter.cs
+++ b/src/Converter/TypeConverter.cs
@@ -38,9 +38,7 @@ namespace Kros.KORM.Converter
         /// </returns>
         /// <exception cref="System.NotImplementedException"></exception>
         public object Convert(object value)
-        {
-            return System.Convert.ChangeType(value, _clrType);
-        }
+            => value is not null ? System.Convert.ChangeType(value, _clrType) : null;
 
         /// <summary>
         /// Converts the value from Clr to Db.
@@ -51,8 +49,6 @@ namespace Kros.KORM.Converter
         /// </returns>
         /// <exception cref="System.NotImplementedException"></exception>
         public object ConvertBack(object value)
-        {
-            return System.Convert.ChangeType(value, _dbType);
-        }
+            => System.Convert.ChangeType(value, _dbType);
     }
 }

--- a/src/Converter/TypeConverter.cs
+++ b/src/Converter/TypeConverter.cs
@@ -12,8 +12,8 @@ namespace Kros.KORM.Converter
     /// </example>
     internal class TypeConverter:IConverter
     {
-        private Type _clrType;
-        private Type _dbType;
+        private readonly Type _clrType;
+        private readonly Type _dbType;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TypeConverter"/> class.

--- a/src/Helper/TypeExtensions.cs
+++ b/src/Helper/TypeExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Reflection;
+
+namespace Kros.KORM.Helper
+{
+    /// <summary>
+    /// Type extensions.
+    /// </summary>
+    internal static class TypeExtensions
+    {
+        /// <summary>
+        /// Gets the constructor info.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        public static (ConstructorInfo ctor, bool isDefault) GetConstructor(this Type type)
+        {
+            ConstructorInfo ctor = type.GetConstructor(
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                null, Type.EmptyTypes, null);
+
+            if (ctor is not null)
+            {
+                return (ctor, true);
+            }
+
+            ConstructorInfo[] ctors = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public);
+
+            if (ctors.Length == 1)
+            {
+                return (ctors[0], false);
+            }
+
+            return (null, false);
+        }
+    }
+}

--- a/src/Kros.KORM.csproj
+++ b/src/Kros.KORM.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
+  <PropertyGroup >
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/Materializer/DynamicMethodModelFactory.cs
+++ b/src/Materializer/DynamicMethodModelFactory.cs
@@ -5,7 +5,6 @@ using Kros.KORM.Injection;
 using Kros.KORM.Metadata;
 using Kros.Utils;
 using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/Materializer/DynamicMethodModelFactory.cs
+++ b/src/Materializer/DynamicMethodModelFactory.cs
@@ -3,6 +3,7 @@ using Kros.KORM.Converter;
 using Kros.KORM.Helper;
 using Kros.KORM.Injection;
 using Kros.KORM.Metadata;
+using Kros.KORM.Properties;
 using Kros.Utils;
 using System;
 using System.Data;
@@ -111,7 +112,7 @@ namespace Kros.KORM.Materializer
         {
             if (reader.IsDBNull(0))
             {
-                return default(T);
+                return default;
             }
 
             Type destType = typeof(T);
@@ -130,7 +131,7 @@ namespace Kros.KORM.Materializer
             }
         }
 
-        private void EmitReaderFields(IDataReader reader,
+        private static void EmitReaderFields(IDataReader reader,
             TableInfo tableInfo,
             ILGenerator ilGenerator,
             IInjector injector)
@@ -143,7 +144,7 @@ namespace Kros.KORM.Materializer
             EmitPropertyForInjecting(tableInfo, ilGenerator, injector);
         }
 
-        private void EmitPropertyForInjecting(TableInfo tableInfo,
+        private static void EmitPropertyForInjecting(TableInfo tableInfo,
             ILGenerator ilGenerator,
             IInjector injector)
         {
@@ -157,7 +158,7 @@ namespace Kros.KORM.Materializer
             }
         }
 
-        private void EmitField(IDataReader reader,
+        private static void EmitField(IDataReader reader,
             TableInfo tableInfo,
             ILGenerator ilGenerator,
             int columnIndex)
@@ -190,9 +191,7 @@ namespace Kros.KORM.Materializer
 
             if (info.ctor is null)
             {
-                throw new InvalidOperationException(
-                    @$"Type '[{type.FullName}]' should have only one public or non-public default constructor
-or only one public parametrized constructor.");
+                throw new InvalidOperationException(string.Format(Resources.Error_TooManyConstructors, type.FullName));
             }
 
             return info;

--- a/src/Materializer/DynamicMethodModelFactory.cs
+++ b/src/Materializer/DynamicMethodModelFactory.cs
@@ -1,6 +1,6 @@
 ﻿using Kros.Caching;
-using Kros.Extensions;
 using Kros.KORM.Converter;
+using Kros.KORM.Helper;
 using Kros.KORM.Injection;
 using Kros.KORM.Metadata;
 using Kros.Utils;
@@ -17,31 +17,14 @@ namespace Kros.KORM.Materializer
     /// <summary>
     /// Modelfactory, which materialize model by dynamic method delegates.
     /// </summary>
-    /// <seealso cref="Kros.KORM.Materializer.IModelFactory" />
+    /// <seealso cref="IModelFactory" />
     public class DynamicMethodModelFactory : IModelFactory
     {
         #region Private fields
 
-        private IDatabaseMapper _databaseMapper;
-        private ICache<int, Delegate> _factoriesCache = new Cache<int, Delegate>();
-        private ReaderKeyGenerator _keyGenerator = new ReaderKeyGenerator();
-        private readonly static List<IConverter> _converters = new List<IConverter>();
-        private readonly static List<IInjector> _injectors = new List<IInjector>();
-
-        private readonly static MethodInfo _fnIsDBNull = typeof(IDataRecord).GetMethod("IsDBNull");
-        private readonly static MethodInfo _fnGetValue = typeof(IDataRecord).GetMethod("GetValue", new Type[] { typeof(int) });
-        private readonly static MethodInfo _fnConvert = typeof(IConverter).GetMethod("Convert");
-        private readonly static FieldInfo _fldConverters = typeof(DynamicMethodModelFactory).GetField(nameof(_converters),
-            BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
-        private readonly static FieldInfo _fldInjectors = typeof(DynamicMethodModelFactory).GetField(nameof(_injectors),
-            BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
-        private readonly static MethodInfo _fnConvertersListGetItem = typeof(List<IConverter>).GetProperty("Item").GetGetMethod();
-        private readonly static MethodInfo _fnInjectorsListGetItem = typeof(List<IInjector>).GetProperty("Item").GetGetMethod();
-        private readonly static MethodInfo _fnInjectorMethodInfo =
-            typeof(IInjector).GetMethod(nameof(IInjector.GetValue), new Type[] { typeof(string) });
-        private readonly static Dictionary<string, MethodInfo> _readerValueGetters = InitReaderValueGetters();
-        private readonly static MethodInfo _getValueMethodInfo =
-            typeof(IDataRecord).GetMethod("GetValue", new Type[] { typeof(int) });
+        private readonly IDatabaseMapper _databaseMapper;
+        private readonly ICache<int, Delegate> _factoriesCache = new Cache<int, Delegate>();
+        private readonly ReaderKeyGenerator _keyGenerator = new ReaderKeyGenerator();
 
         #endregion
 
@@ -72,7 +55,7 @@ namespace Kros.KORM.Materializer
         {
             Check.NotNull(reader, nameof(reader));
 
-            var key = _keyGenerator.GenerateKey<T>(reader);
+            int key = _keyGenerator.GenerateKey<T>(reader);
 
             return _factoriesCache.Get(key, () => CreateFactory<T>(reader)) as Func<IDataReader, T>;
         }
@@ -87,23 +70,41 @@ namespace Kros.KORM.Materializer
             else
             {
                 TableInfo tableInfo = _databaseMapper.GetTableInfo<T>();
-                var injector = _databaseMapper.GetInjector<T>();
+                IInjector injector = _databaseMapper.GetInjector<T>();
+                (ConstructorInfo ctor, bool isDefault) = GetConstructor(type);
 
-                var dynamicMethod = new DynamicMethod(string.Format("korm_factory_{0}", _factoriesCache.Count),
-                    type, new Type[] { typeof(IDataReader) }, true);
-                var ilGenerator = dynamicMethod.GetILGenerator();
-
-                ConstructorInfo ctor = GetConstructor(type);
-                ilGenerator.Emit(OpCodes.Newobj, ctor);
-
-                EmitReaderFields(reader, tableInfo, ilGenerator, injector);
-
-                CallOnAfterMaterialize(tableInfo, ilGenerator);
-
-                ilGenerator.Emit(OpCodes.Ret);
-
-                return dynamicMethod.CreateDelegate(Expression.GetFuncType(typeof(IDataReader), type)) as Func<IDataReader, T>;
+                if (isDefault)
+                {
+                    return CreateFactoryForPropertySetters<T>(reader, tableInfo, injector, ctor);
+                }
+                else
+                {
+                    return RecordModelFactory.CreateFactoryForRecords<T>(reader, tableInfo, injector, ctor);
+                }
             }
+        }
+
+        private string GetFactoryName => $"korm_factory_{_factoriesCache.Count}";
+
+        private Func<IDataReader, T> CreateFactoryForPropertySetters<T>(
+            IDataReader reader,
+            TableInfo tableInfo,
+            IInjector injector,
+            ConstructorInfo ctor)
+        {
+            Type type = typeof(T);
+            var dynamicMethod = new DynamicMethod(GetFactoryName, type, new Type[] { typeof(IDataReader) }, true);
+            ILGenerator ilGenerator = dynamicMethod.GetILGenerator();
+
+            ilGenerator.Emit(OpCodes.Newobj, ctor);
+
+            EmitReaderFields(reader, tableInfo, ilGenerator, injector);
+
+            ilGenerator.CallOnAfterMaterialize(tableInfo);
+
+            ilGenerator.Emit(OpCodes.Ret);
+
+            return dynamicMethod.CreateDelegate(Expression.GetFuncType(typeof(IDataReader), type)) as Func<IDataReader, T>;
         }
 
         // ToDo: Zrefaktorovať aby sa používal DynamicMethods.
@@ -117,9 +118,9 @@ namespace Kros.KORM.Materializer
             Type destType = typeof(T);
             Type srcType = reader.GetFieldType(0);
 
-            var valueGetter = GetReaderValueGetter(srcType);
+            MethodInfo valueGetter = srcType.GetReaderValueGetter();
 
-            var value = valueGetter.Invoke(reader, new object[] { 0 });
+            object value = valueGetter.Invoke(reader, new object[] { 0 });
             if (destType.Name == srcType.Name)
             {
                 return (T)value;
@@ -127,23 +128,6 @@ namespace Kros.KORM.Materializer
             else
             {
                 return (T)Convert.ChangeType(value, destType);
-            }
-        }
-
-        private static void CallOnAfterMaterialize(TableInfo tableInfo, ILGenerator ilGenerator)
-        {
-            if (tableInfo.OnAfterMaterialize != null)
-            {
-                ilGenerator.Emit(OpCodes.Dup);
-                ilGenerator.Emit(OpCodes.Ldarg_0);
-                if (tableInfo.OnAfterMaterialize.IsVirtual)
-                {
-                    ilGenerator.Emit(OpCodes.Callvirt, tableInfo.OnAfterMaterialize);
-                }
-                else
-                {
-                    ilGenerator.Emit(OpCodes.Call, tableInfo.OnAfterMaterialize);
-                }
             }
         }
 
@@ -164,35 +148,14 @@ namespace Kros.KORM.Materializer
             ILGenerator ilGenerator,
             IInjector injector)
         {
-            foreach (var property in tableInfo
+            foreach (PropertyInfo property in tableInfo
                 .AllModelProperties
                 .Where(p => injector.IsInjectable(p.Name)))
             {
-                int injectorIndex = GetInjectorIndex(injector);
-
                 ilGenerator.Emit(OpCodes.Dup);
-                ilGenerator.Emit(OpCodes.Ldsfld, _fldInjectors);
-                ilGenerator.Emit(OpCodes.Ldc_I4, injectorIndex);
-                ilGenerator.Emit(OpCodes.Callvirt, _fnInjectorsListGetItem);
-
-                ilGenerator.Emit(OpCodes.Ldstr, property.Name);
-                ilGenerator.Emit(OpCodes.Callvirt, _fnInjectorMethodInfo);
-
-                ilGenerator.Emit(OpCodes.Unbox_Any, property.PropertyType);
+                ilGenerator.CallGetInjectedValue(injector, property.Name, property.PropertyType);
                 ilGenerator.Emit(OpCodes.Callvirt, property.GetSetMethod(true));
             }
-        }
-
-        private static int GetInjectorIndex(IInjector injector)
-        {
-            var injectorIndex = _injectors.IndexOf(injector);
-            if (injectorIndex == -1)
-            {
-                _injectors.Add(injector);
-                injectorIndex = _injectors.Count - 1;
-            }
-
-            return injectorIndex;
         }
 
         private void EmitField(IDataReader reader,
@@ -200,157 +163,40 @@ namespace Kros.KORM.Materializer
             ILGenerator ilGenerator,
             int columnIndex)
         {
-            var columnInfo = tableInfo.GetColumnInfo(reader.GetName(columnIndex));
+            ColumnInfo columnInfo = tableInfo.GetColumnInfo(reader.GetName(columnIndex));
             if (columnInfo != null)
             {
-                var srcType = reader.GetFieldType(columnIndex);
+                Type srcType = reader.GetFieldType(columnIndex);
 
-                ilGenerator.Emit(OpCodes.Ldarg_0);
-                ilGenerator.Emit(OpCodes.Ldc_I4, columnIndex);
-                ilGenerator.Emit(OpCodes.Callvirt, _fnIsDBNull);
-                var lblNext = ilGenerator.DefineLabel();
-                ilGenerator.Emit(OpCodes.Brtrue_S, lblNext);
-
-                ilGenerator.Emit(OpCodes.Dup);
-                var converter = ConverterHelper.GetConverter(columnInfo, srcType);
+                Label truePart = ilGenerator.CallReaderIsDbNull(columnIndex);
+                IConverter converter = ConverterHelper.GetConverter(columnInfo, srcType);
 
                 if (converter == null)
                 {
-                    FillingValuesWithoutConverter(ilGenerator, columnIndex, columnInfo, srcType);
+                    ilGenerator.CallReaderGetValueWithoutConverter(columnIndex, columnInfo, srcType);
                 }
                 else
                 {
-                    FillingValuesWithConverter(ilGenerator, columnIndex, columnInfo, converter);
+                    ilGenerator.CallReaderGetValueWithConverter(columnIndex, converter, columnInfo);
                 }
 
-                ilGenerator.MarkLabel(lblNext);
+                ilGenerator.Emit(OpCodes.Callvirt, columnInfo.PropertyInfo.GetSetMethod(true));
+                ilGenerator.MarkLabel(truePart);
             }
         }
 
-        private static ConstructorInfo GetConstructor(Type type)
+        private static (ConstructorInfo ctor, bool isDefault) GetConstructor(Type type)
         {
-            var ctor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
-                            null, new Type[0], null);
-            if (ctor == null)
-            {
-                throw new InvalidOperationException($"Type '[{type.FullName}]' should have default public or non-public constructor");
-            }
+            (ConstructorInfo ctor, bool isDefault) info = type.GetConstructor();
 
-            return ctor;
-        }
-
-        private static void FillingValuesWithConverter(ILGenerator ilGenerator,
-                                                               int fieldIndex,
-                                                        ColumnInfo columnInfo,
-                                                        IConverter converter)
-        {
-            int converterIndex = _converters.Count;
-            _converters.Add(converter);
-
-            ilGenerator.Emit(OpCodes.Ldsfld, _fldConverters);
-            ilGenerator.Emit(OpCodes.Ldc_I4, converterIndex);
-            ilGenerator.Emit(OpCodes.Callvirt, _fnConvertersListGetItem);
-
-            ilGenerator.Emit(OpCodes.Ldarg_0);
-            ilGenerator.Emit(OpCodes.Ldc_I4, fieldIndex);
-            ilGenerator.Emit(OpCodes.Callvirt, _fnGetValue);
-
-            ilGenerator.Emit(OpCodes.Callvirt, _fnConvert);
-
-            ilGenerator.Emit(OpCodes.Unbox_Any, columnInfo.PropertyInfo.PropertyType);
-            ilGenerator.Emit(OpCodes.Callvirt, columnInfo.PropertyInfo.GetSetMethod(true));
-        }
-
-        private static void FillingValuesWithoutConverter(ILGenerator ilGenerator,
-                                                                  int fieldIndex,
-                                                           ColumnInfo columnInfo,
-                                                                 Type srcType)
-        {
-            bool castNeeded = false;
-
-            MethodInfo valuegetter = GetReaderValueGetter(srcType);
-
-            if (valuegetter != null
-                && valuegetter.ReturnType == srcType
-                && (valuegetter.ReturnType == columnInfo.PropertyInfo.PropertyType ||
-                    valuegetter.ReturnType == Nullable.GetUnderlyingType(columnInfo.PropertyInfo.PropertyType)))
-            {
-                castNeeded = false;
-            }
-            else if ((srcType == columnInfo.PropertyInfo.PropertyType) ||
-                     (srcType == Nullable.GetUnderlyingType(columnInfo.PropertyInfo.PropertyType)))
-            {
-                valuegetter = _getValueMethodInfo;
-                castNeeded = true;
-            }
-            else
+            if (info.ctor is null)
             {
                 throw new InvalidOperationException(
-                    Properties.Resources.CannotMaterializeSourceValue.Format(srcType, columnInfo.PropertyInfo.PropertyType));
+                    @$"Type '[{type.FullName}]' should have only one public or non-public default constructor
+or only one public parametrized constructor.");
             }
 
-            ilGenerator.Emit(OpCodes.Ldarg_0);
-            ilGenerator.Emit(OpCodes.Ldc_I4, fieldIndex);
-            ilGenerator.Emit(OpCodes.Callvirt, valuegetter);
-
-            if (castNeeded)
-            {
-                EmitCastValue(ilGenerator, columnInfo, srcType);
-            }
-            else
-            {
-                if (Nullable.GetUnderlyingType(columnInfo.PropertyInfo.PropertyType) != null)
-                {
-                    ilGenerator.Emit(OpCodes.Newobj,
-                        columnInfo.PropertyInfo.PropertyType.GetConstructor(
-                            new Type[] { Nullable.GetUnderlyingType(columnInfo.PropertyInfo.PropertyType) }));
-                }
-            }
-
-            ilGenerator.Emit(OpCodes.Callvirt, columnInfo.PropertyInfo.GetSetMethod(true));
+            return info;
         }
-
-        private static void EmitCastValue(ILGenerator ilGenerator, ColumnInfo columnInfo, Type srcType)
-        {
-            if (srcType.IsValueType)
-            {
-                ilGenerator.Emit(OpCodes.Unbox_Any, columnInfo.PropertyInfo.PropertyType);
-            }
-            else
-            {
-                ilGenerator.Emit(OpCodes.Castclass, columnInfo.PropertyInfo.PropertyType);
-            }
-        }
-
-        private static Dictionary<string, MethodInfo> InitReaderValueGetters()
-        {
-            var getters = new Dictionary<string, MethodInfo>(StringComparer.CurrentCultureIgnoreCase);
-
-            MethodInfo CreateReaderValueGetter(string typeName)
-                => typeof(IDataRecord).GetMethod($"Get{typeName}", new Type[] { typeof(int) });
-
-            void Add<T>()
-                => getters.Add(typeof(T).Name, CreateReaderValueGetter(typeof(T).Name));
-
-            Add<Boolean>();
-            Add<Byte>();
-            Add<Char>();
-            Add<DateTime>();
-            Add<Decimal>();
-            Add<Double>();
-            Add<Guid>();
-            Add<Int16>();
-            Add<Int32>();
-            Add<Int64>();
-
-            Add<String>();
-
-            getters.Add(nameof(Single), CreateReaderValueGetter("Float"));
-
-            return getters;
-        }
-
-        private static MethodInfo GetReaderValueGetter(Type srcType)
-            => _readerValueGetters.ContainsKey(srcType.Name) ? _readerValueGetters[srcType.Name] : null;
     }
 }

--- a/src/Materializer/ILGeneratorExtensions.cs
+++ b/src/Materializer/ILGeneratorExtensions.cs
@@ -1,0 +1,212 @@
+﻿using Kros.Extensions;
+using Kros.KORM.Converter;
+using Kros.KORM.Injection;
+using Kros.KORM.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Kros.KORM.Materializer
+{
+    internal static class ILGeneratorExtensions
+    {
+        private readonly static List<IConverter> _converters = new List<IConverter>();
+        private readonly static Dictionary<string, MethodInfo> _readerValueGetters = InitReaderValueGetters();
+        private readonly static MethodInfo _fnIsDBNull = typeof(IDataRecord).GetMethod(nameof(IDataReader.IsDBNull));
+        private readonly static MethodInfo _getValueMethodInfo =
+            typeof(IDataRecord).GetMethod("GetValue", new Type[] { typeof(int) });
+        private readonly static FieldInfo _fldConverters = typeof(ILGeneratorExtensions).GetField(nameof(_converters),
+            BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
+        private readonly static MethodInfo _fnConvertersListGetItem = typeof(List<IConverter>).GetProperty("Item").GetGetMethod();
+        private readonly static MethodInfo _fnGetValue = typeof(IDataRecord).GetMethod("GetValue", new Type[] { typeof(int) });
+        private readonly static MethodInfo _fnConvert = typeof(IConverter).GetMethod("Convert");
+        private readonly static List<IInjector> _injectors = new List<IInjector>();
+        private readonly static FieldInfo _fldInjectors = typeof(ILGeneratorExtensions).GetField(nameof(_injectors),
+            BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
+        private readonly static MethodInfo _fnInjectorsListGetItem = typeof(List<IInjector>).GetProperty("Item").GetGetMethod();
+        private readonly static MethodInfo _fnInjectorMethodInfo =
+            typeof(IInjector).GetMethod(nameof(IInjector.GetValue), new Type[] { typeof(string) });
+
+        public static ILGenerator CallReaderMethod(this ILGenerator iLGenerator, int fieldIndex, MethodInfo methodInfo)
+        {
+            iLGenerator.Emit(OpCodes.Ldarg_0);
+            iLGenerator.Emit(OpCodes.Ldc_I4, fieldIndex);
+            iLGenerator.Emit(OpCodes.Callvirt, methodInfo);
+
+            return iLGenerator;
+        }
+
+        public static Label CallReaderIsDbNull(this ILGenerator iLGenerator, int fieldIndex)
+        {
+            iLGenerator.Emit(OpCodes.Ldarg_0);
+            iLGenerator.Emit(OpCodes.Ldc_I4, fieldIndex);
+            iLGenerator.Emit(OpCodes.Callvirt, _fnIsDBNull);
+            Label truePart = iLGenerator.DefineLabel();
+            iLGenerator.Emit(OpCodes.Brtrue_S, truePart);
+
+            iLGenerator.Emit(OpCodes.Dup);
+
+            return truePart;
+        }
+
+        public static MethodInfo GetReaderValueGetter(this Type srcType)
+            => _readerValueGetters.ContainsKey(srcType.Name) ? _readerValueGetters[srcType.Name] : null;
+
+        public static void CallReaderGetValueWithoutConverter(
+            this ILGenerator iLGenerator,
+            int fieldIndex,
+            ColumnInfo columnInfo,
+            Type srcType)
+        {
+            MethodInfo valuegetter = srcType.GetReaderValueGetter();
+
+            bool castNeeded;
+            if (valuegetter != null
+                && valuegetter.ReturnType == srcType
+                && (valuegetter.ReturnType == columnInfo.PropertyInfo.PropertyType ||
+                valuegetter.ReturnType == Nullable.GetUnderlyingType(columnInfo.PropertyInfo.PropertyType)))
+            {
+                castNeeded = false;
+            }
+            else if ((srcType == columnInfo.PropertyInfo.PropertyType) ||
+                     (srcType == Nullable.GetUnderlyingType(columnInfo.PropertyInfo.PropertyType)))
+            {
+                valuegetter = _getValueMethodInfo;
+                castNeeded = true;
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    Properties.Resources.CannotMaterializeSourceValue.Format(srcType, columnInfo.PropertyInfo.PropertyType));
+            }
+
+            iLGenerator.CallReaderMethod(fieldIndex, valuegetter);
+
+            if (castNeeded)
+            {
+                EmitCastValue(iLGenerator, columnInfo, srcType);
+            }
+            else
+            {
+                if (Nullable.GetUnderlyingType(columnInfo.PropertyInfo.PropertyType) != null)
+                {
+                    iLGenerator.Emit(OpCodes.Newobj,
+                        columnInfo.PropertyInfo.PropertyType.GetConstructor(
+                            new Type[] { Nullable.GetUnderlyingType(columnInfo.PropertyInfo.PropertyType) }));
+                }
+            }
+        }
+
+        public static void CallReaderGetValueWithConverter(
+            this ILGenerator iLGenerator,
+            int fieldIndex,
+            IConverter converter,
+            ColumnInfo columnInfo)
+        {
+            int converterIndex = _converters.Count;
+            _converters.Add(converter);
+
+            iLGenerator.Emit(OpCodes.Ldsfld, _fldConverters);
+            iLGenerator.Emit(OpCodes.Ldc_I4, converterIndex);
+            iLGenerator.Emit(OpCodes.Callvirt, _fnConvertersListGetItem);
+
+            iLGenerator.Emit(OpCodes.Ldarg_0);
+            iLGenerator.Emit(OpCodes.Ldc_I4, fieldIndex);
+            iLGenerator.Emit(OpCodes.Callvirt, _fnGetValue);
+
+            iLGenerator.Emit(OpCodes.Callvirt, _fnConvert);
+            iLGenerator.Emit(OpCodes.Unbox_Any, columnInfo.PropertyInfo.PropertyType);
+        }
+
+        public static void CallGetInjectedValue(
+            this ILGenerator iLGenerator,
+            IInjector injector,
+            string propertyName,
+            Type propertyType)
+        {
+            int injectorIndex = GetInjectorIndex(injector);
+
+            iLGenerator.Emit(OpCodes.Ldsfld, _fldInjectors);
+            iLGenerator.Emit(OpCodes.Ldc_I4, injectorIndex);
+            iLGenerator.Emit(OpCodes.Callvirt, _fnInjectorsListGetItem);
+
+            iLGenerator.Emit(OpCodes.Ldstr, propertyName);
+            iLGenerator.Emit(OpCodes.Callvirt, _fnInjectorMethodInfo);
+
+            iLGenerator.Emit(OpCodes.Unbox_Any, propertyType);
+        }
+
+        public static void CallOnAfterMaterialize(
+            this ILGenerator iLGenerator,
+            TableInfo tableInfo)
+        {
+            if (tableInfo.OnAfterMaterialize != null)
+            {
+                iLGenerator.Emit(OpCodes.Dup);
+                iLGenerator.Emit(OpCodes.Ldarg_0);
+                if (tableInfo.OnAfterMaterialize.IsVirtual)
+                {
+                    iLGenerator.Emit(OpCodes.Callvirt, tableInfo.OnAfterMaterialize);
+                }
+                else
+                {
+                    iLGenerator.Emit(OpCodes.Call, tableInfo.OnAfterMaterialize);
+                }
+            }
+        }
+
+        private static void EmitCastValue(ILGenerator iLGenerator, ColumnInfo columnInfo, Type srcType)
+        {
+            if (srcType.IsValueType)
+            {
+                iLGenerator.Emit(OpCodes.Unbox_Any, columnInfo.PropertyInfo.PropertyType);
+            }
+            else
+            {
+                iLGenerator.Emit(OpCodes.Castclass, columnInfo.PropertyInfo.PropertyType);
+            }
+        }
+
+        private static Dictionary<string, MethodInfo> InitReaderValueGetters()
+        {
+            var getters = new Dictionary<string, MethodInfo>(StringComparer.CurrentCultureIgnoreCase);
+
+            MethodInfo CreateReaderValueGetter(string typeName)
+                => typeof(IDataRecord).GetMethod($"Get{typeName}", new Type[] { typeof(int) });
+
+            void Add<T>()
+                => getters.Add(typeof(T).Name, CreateReaderValueGetter(typeof(T).Name));
+
+            Add<Boolean>();
+            Add<Byte>();
+            Add<Char>();
+            Add<DateTime>();
+            Add<Decimal>();
+            Add<Double>();
+            Add<Guid>();
+            Add<Int16>();
+            Add<Int32>();
+            Add<Int64>();
+
+            Add<String>();
+
+            getters.Add(nameof(Single), CreateReaderValueGetter("Float"));
+
+            return getters;
+        }
+
+        private static int GetInjectorIndex(IInjector injector)
+        {
+            var injectorIndex = _injectors.IndexOf(injector);
+            if (injectorIndex == -1)
+            {
+                _injectors.Add(injector);
+                injectorIndex = _injectors.Count - 1;
+            }
+
+            return injectorIndex;
+        }
+    }
+}

--- a/src/Materializer/ILGeneratorHelper.cs
+++ b/src/Materializer/ILGeneratorHelper.cs
@@ -65,13 +65,13 @@ namespace Kros.KORM.Materializer
             bool castNeeded;
             if (valuegetter != null
                 && valuegetter.ReturnType == srcType
-                && (valuegetter.ReturnType == columnInfo.PropertyInfo.PropertyType ||
-                valuegetter.ReturnType == Nullable.GetUnderlyingType(columnInfo.PropertyInfo.PropertyType)))
+                && (valuegetter.ReturnType == columnInfo.PropertyInfo.PropertyType
+                || valuegetter.ReturnType == Nullable.GetUnderlyingType(columnInfo.PropertyInfo.PropertyType)))
             {
                 castNeeded = false;
             }
-            else if ((srcType == columnInfo.PropertyInfo.PropertyType) ||
-                     (srcType == Nullable.GetUnderlyingType(columnInfo.PropertyInfo.PropertyType)))
+            else if ((srcType == columnInfo.PropertyInfo.PropertyType)
+                || (srcType == Nullable.GetUnderlyingType(columnInfo.PropertyInfo.PropertyType)))
             {
                 valuegetter = _getValueMethodInfo;
                 castNeeded = true;
@@ -171,7 +171,7 @@ namespace Kros.KORM.Materializer
 
         private static Dictionary<string, MethodInfo> InitReaderValueGetters()
         {
-            var getters = new Dictionary<string, MethodInfo>(StringComparer.CurrentCultureIgnoreCase);
+            var getters = new Dictionary<string, MethodInfo>(StringComparer.OrdinalIgnoreCase);
 
             MethodInfo CreateReaderValueGetter(string typeName)
                 => typeof(IDataRecord).GetMethod($"Get{typeName}", new Type[] { typeof(int) });
@@ -179,18 +179,18 @@ namespace Kros.KORM.Materializer
             void Add<T>()
                 => getters.Add(typeof(T).Name, CreateReaderValueGetter(typeof(T).Name));
 
-            Add<Boolean>();
-            Add<Byte>();
-            Add<Char>();
+            Add<bool>();
+            Add<byte>();
+            Add<char>();
             Add<DateTime>();
-            Add<Decimal>();
-            Add<Double>();
+            Add<decimal>();
+            Add<double>();
             Add<Guid>();
-            Add<Int16>();
-            Add<Int32>();
-            Add<Int64>();
+            Add<short>();
+            Add<int>();
+            Add<long>();
 
-            Add<String>();
+            Add<string>();
 
             getters.Add(nameof(Single), CreateReaderValueGetter("Float"));
 

--- a/src/Materializer/ILGeneratorHelper.cs
+++ b/src/Materializer/ILGeneratorHelper.cs
@@ -10,20 +10,20 @@ using System.Reflection.Emit;
 
 namespace Kros.KORM.Materializer
 {
-    internal static class ILGeneratorExtensions
+    internal static class ILGeneratorHelper
     {
         private readonly static List<IConverter> _converters = new List<IConverter>();
         private readonly static Dictionary<string, MethodInfo> _readerValueGetters = InitReaderValueGetters();
         private readonly static MethodInfo _fnIsDBNull = typeof(IDataRecord).GetMethod(nameof(IDataReader.IsDBNull));
         private readonly static MethodInfo _getValueMethodInfo =
             typeof(IDataRecord).GetMethod("GetValue", new Type[] { typeof(int) });
-        private readonly static FieldInfo _fldConverters = typeof(ILGeneratorExtensions).GetField(nameof(_converters),
+        private readonly static FieldInfo _fldConverters = typeof(ILGeneratorHelper).GetField(nameof(_converters),
             BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
         private readonly static MethodInfo _fnConvertersListGetItem = typeof(List<IConverter>).GetProperty("Item").GetGetMethod();
         private readonly static MethodInfo _fnGetValue = typeof(IDataRecord).GetMethod("GetValue", new Type[] { typeof(int) });
         private readonly static MethodInfo _fnConvert = typeof(IConverter).GetMethod("Convert");
         private readonly static List<IInjector> _injectors = new List<IInjector>();
-        private readonly static FieldInfo _fldInjectors = typeof(ILGeneratorExtensions).GetField(nameof(_injectors),
+        private readonly static FieldInfo _fldInjectors = typeof(ILGeneratorHelper).GetField(nameof(_injectors),
             BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
         private readonly static MethodInfo _fnInjectorsListGetItem = typeof(List<IInjector>).GetProperty("Item").GetGetMethod();
         private readonly static MethodInfo _fnInjectorMethodInfo =

--- a/src/Materializer/RecordModelFactory.cs
+++ b/src/Materializer/RecordModelFactory.cs
@@ -29,13 +29,13 @@ namespace Kros.KORM.Materializer
 
             foreach (ParameterInfo param in paramsInfo)
             {
-                ColumnInfo columnInfo = tableInfo.GetColumnInfoByPropertyName(param.Name);
                 if (injector.IsInjectable(param.Name))
                 {
                     iLGenerator.CallGetInjectedValue(injector, param.Name, param.ParameterType);
                 }
                 else
                 {
+                    ColumnInfo columnInfo = tableInfo.GetColumnInfoByPropertyName(param.Name);
                     FromReader(reader, iLGenerator, columnInfo);
                 }
             }
@@ -56,7 +56,7 @@ namespace Kros.KORM.Materializer
 
             IConverter converter = ConverterHelper.GetConverter(columnInfo, srcType);
 
-            if (converter == null)
+            if (converter is null)
             {
                 iLGenerator.CallReaderGetValueWithoutConverter(ordinal, columnInfo, srcType);
             }

--- a/src/Materializer/RecordModelFactory.cs
+++ b/src/Materializer/RecordModelFactory.cs
@@ -1,0 +1,64 @@
+﻿using Kros.KORM.Converter;
+using Kros.KORM.Injection;
+using Kros.KORM.Metadata;
+using System;
+using System.Data;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Kros.KORM.Materializer
+{
+    /// <summary>
+    /// Model factory for record types.
+    /// </summary>
+    internal static class RecordModelFactory
+    {
+        public static Func<IDataReader, T> CreateFactoryForRecords<T>(
+           IDataReader reader,
+           TableInfo tableInfo,
+           IInjector injector,
+           ConstructorInfo ctor)
+        {
+            Type type = typeof(T);
+            var dynamicMethod = new DynamicMethod(
+                $"korm_factory_record_{typeof(T).Name}",
+                type, new Type[] { typeof(IDataReader) }, true);
+            ILGenerator iLGenerator = dynamicMethod.GetILGenerator();
+            ParameterInfo[] paramsInfo = ctor.GetParameters();
+
+            foreach (ParameterInfo param in paramsInfo)
+            {
+                ColumnInfo columnInfo = tableInfo.GetColumnInfoByPropertyName(param.Name);
+                if (injector.IsInjectable(param.Name))
+                {
+                    iLGenerator.CallGetInjectedValue(injector, param.Name, param.ParameterType);
+                }
+                else
+                {
+                    string fieldName = columnInfo.Name;
+                    int ordinal = reader.GetOrdinal(fieldName);
+
+                    Type srcType = reader.GetFieldType(ordinal);
+
+                    IConverter converter = ConverterHelper.GetConverter(columnInfo, srcType);
+
+                    if (converter == null)
+                    {
+                        iLGenerator.CallReaderGetValueWithoutConverter(ordinal, columnInfo, srcType);
+                    }
+                    else
+                    {
+                        iLGenerator.CallReaderGetValueWithConverter(ordinal, converter, columnInfo);
+                    }
+                }
+            }
+
+            iLGenerator.Emit(OpCodes.Newobj, ctor);
+            iLGenerator.CallOnAfterMaterialize(tableInfo);
+            iLGenerator.Emit(OpCodes.Ret);
+
+            return dynamicMethod.CreateDelegate(Expression.GetFuncType(typeof(IDataReader), type)) as Func<IDataReader, T>;
+        }
+    }
+}

--- a/src/Materializer/RecordModelFactory.cs
+++ b/src/Materializer/RecordModelFactory.cs
@@ -36,21 +36,7 @@ namespace Kros.KORM.Materializer
                 }
                 else
                 {
-                    string fieldName = columnInfo.Name;
-                    int ordinal = reader.GetOrdinal(fieldName);
-
-                    Type srcType = reader.GetFieldType(ordinal);
-
-                    IConverter converter = ConverterHelper.GetConverter(columnInfo, srcType);
-
-                    if (converter == null)
-                    {
-                        iLGenerator.CallReaderGetValueWithoutConverter(ordinal, columnInfo, srcType);
-                    }
-                    else
-                    {
-                        iLGenerator.CallReaderGetValueWithConverter(ordinal, converter, columnInfo);
-                    }
+                    FromReader(reader, iLGenerator, columnInfo);
                 }
             }
 
@@ -59,6 +45,25 @@ namespace Kros.KORM.Materializer
             iLGenerator.Emit(OpCodes.Ret);
 
             return dynamicMethod.CreateDelegate(Expression.GetFuncType(typeof(IDataReader), type)) as Func<IDataReader, T>;
+        }
+
+        private static void FromReader(IDataReader reader, ILGenerator iLGenerator, ColumnInfo columnInfo)
+        {
+            string fieldName = columnInfo.Name;
+            int ordinal = reader.GetOrdinal(fieldName);
+
+            Type srcType = reader.GetFieldType(ordinal);
+
+            IConverter converter = ConverterHelper.GetConverter(columnInfo, srcType);
+
+            if (converter == null)
+            {
+                iLGenerator.CallReaderGetValueWithoutConverter(ordinal, columnInfo, srcType);
+            }
+            else
+            {
+                iLGenerator.CallReaderGetValueWithConverter(ordinal, converter, columnInfo);
+            }
         }
     }
 }

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -11,3 +11,4 @@ using System.Runtime.InteropServices;
 
 [assembly: InternalsVisibleTo("Kros.KORM.UnitTests")]
 [assembly: InternalsVisibleTo("Kros.KORM.MsAccess.UnitTests")]
+[assembly: InternalsVisibleTo("Kros.KORM.PerformanceTests")]

--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -205,6 +205,16 @@ namespace Kros.KORM.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Type &apos;{0}&apos; should have only one public or non-public default constructor
+        ///or only one public parametrized constructor..
+        /// </summary>
+        internal static string Error_TooManyConstructors {
+            get {
+                return ResourceManager.GetString("Error_TooManyConstructors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot add item (hash code = {0}). This item already exists in collection {1}..
         /// </summary>
         internal static string ExistingItemCannotBeAdded {

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -168,6 +168,10 @@
   <data name="Error_KormProviderNotSet" xml:space="preserve">
     <value>KORM provider is not set.</value>
   </data>
+  <data name="Error_TooManyConstructors" xml:space="preserve">
+    <value>Type '{0}' should have only one public or non-public default constructor
+or only one public parametrized constructor.</value>
+  </data>
   <data name="ExistingItemCannotBeAdded" xml:space="preserve">
     <value>Cannot add item (hash code = {0}). This item already exists in collection {1}.</value>
   </data>

--- a/tests/Kros.KORM.PerformanceTests/Kros.KORM.PerformanceTests.csproj
+++ b/tests/Kros.KORM.PerformanceTests/Kros.KORM.PerformanceTests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="MMLib.RapidPrototyping" Version="1.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kros.KORM.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Kros.KORM.PerformanceTests/MaterializeToClassVsRecordTest.cs
+++ b/tests/Kros.KORM.PerformanceTests/MaterializeToClassVsRecordTest.cs
@@ -1,0 +1,62 @@
+﻿using BenchmarkDotNet.Attributes;
+using Microsoft.Data.SqlClient;
+using MMLib.RapidPrototyping.Generators;
+using MMLib.RapidPrototyping.Models;
+using System;
+using System.Data;
+
+namespace Kros.KORM.PerformanceTests
+{
+    public class MaterializeToClassVsRecordTest
+    {
+        private DataTable _table;
+        private IDatabase _database;
+
+        public MaterializeToClassVsRecordTest()
+        {
+            _database = new Database(new SqlConnection());
+            _table = new DataTable();
+            _table.Columns.Add("Id", typeof(int));
+            _table.Columns.Add("FirstName", typeof(string));
+            _table.Columns.Add("LastName", typeof(string));
+            _table.Columns.Add("Salary", typeof(double));
+            _table.Columns.Add("IsEmployed", typeof(bool));
+
+            var pg = new PersonGenerator(22);
+            var random = new Random(22);
+            int id = 0;
+
+            foreach (IPerson person in pg.Next(1000))
+            {
+                _table.Rows.Add(++id, person.FirstName, person.LastName, random.NextDouble() * 1000,
+                    Convert.ToBoolean(random.Next(-1, 1)));
+            }
+        }
+
+        [Benchmark]
+        public void RecordTypes()
+        {
+            foreach (Foo employee in _database.ModelBuilder.Materialize<Foo>(_table))
+            {
+            }
+        }
+
+        [Benchmark]
+        public void ClassTypes()
+        {
+            foreach (Bar employee in _database.ModelBuilder.Materialize<Bar>(_table))
+            {
+            }
+        }
+
+        public record Foo(int Id, string FirstName, string LastName, double Salary, bool IsEmployed);
+        public class Bar
+        {
+            public int Id { get; set; }
+            public string FirstName { get; set; }
+            public string LastName { get; set; }
+            public double Salary { get; set; }
+            public bool IsEmployed { get; set; }
+        }
+    }
+}

--- a/tests/Kros.KORM.PerformanceTests/MaterializeToClassVsRecordTest.cs
+++ b/tests/Kros.KORM.PerformanceTests/MaterializeToClassVsRecordTest.cs
@@ -9,8 +9,8 @@ namespace Kros.KORM.PerformanceTests
 {
     public class MaterializeToClassVsRecordTest
     {
-        private DataTable _table;
-        private IDatabase _database;
+        private readonly DataTable _table;
+        private readonly IDatabase _database;
 
         public MaterializeToClassVsRecordTest()
         {
@@ -36,7 +36,7 @@ namespace Kros.KORM.PerformanceTests
         [Benchmark]
         public void RecordTypes()
         {
-            foreach (Foo employee in _database.ModelBuilder.Materialize<Foo>(_table))
+            foreach (RecordType employee in _database.ModelBuilder.Materialize<RecordType>(_table))
             {
             }
         }
@@ -44,13 +44,14 @@ namespace Kros.KORM.PerformanceTests
         [Benchmark]
         public void ClassTypes()
         {
-            foreach (Bar employee in _database.ModelBuilder.Materialize<Bar>(_table))
+            foreach (ClassType employee in _database.ModelBuilder.Materialize<ClassType>(_table))
             {
             }
         }
 
-        public record Foo(int Id, string FirstName, string LastName, double Salary, bool IsEmployed);
-        public class Bar
+        public record RecordType(int Id, string FirstName, string LastName, double Salary, bool IsEmployed);
+
+        public class ClassType
         {
             public int Id { get; set; }
             public string FirstName { get; set; }

--- a/tests/Kros.KORM.PerformanceTests/Program.cs
+++ b/tests/Kros.KORM.PerformanceTests/Program.cs
@@ -1,0 +1,12 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace Kros.KORM.PerformanceTests
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var summary = BenchmarkRunner.Run<MaterializeToClassVsRecordTest>();
+        }
+    }
+}

--- a/tests/Kros.KORM.UnitTests/Helper/DateTimeExtensions.cs
+++ b/tests/Kros.KORM.UnitTests/Helper/DateTimeExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Globalization;
+
+namespace Kros.KORM.UnitTests.Helper
+{
+    internal static class DateTimeExtensions
+    {
+        public static CultureInfo _culture = CultureInfo.GetCultureInfo("sk-SK");
+
+        public static DateTime ParseDateTime(this string dateTime)
+            => DateTime.Parse(dateTime, _culture);
+    }
+}

--- a/tests/Kros.KORM.UnitTests/Helper/InMemoryDataReader.cs
+++ b/tests/Kros.KORM.UnitTests/Helper/InMemoryDataReader.cs
@@ -27,7 +27,7 @@ namespace Kros.KORM.UnitTests.Helper
         {
             _data = data.GetEnumerator();
             _originData = data;
-            if (_originData.Count() > 0)
+            if (_originData.Any())
             {
                 _keys = _originData.First().Keys.ToList();
                 _types = types.ToList();

--- a/tests/Kros.KORM.UnitTests/Helper/InMemoryDataReader.cs
+++ b/tests/Kros.KORM.UnitTests/Helper/InMemoryDataReader.cs
@@ -19,13 +19,18 @@ namespace Kros.KORM.UnitTests.Helper
         private int _fieldCount = 0;
 
         public InMemoryDataReader(IEnumerable<Dictionary<string, object>> data)
+            : this(data, data.Any() ? data.First().Values.Select(p => p.GetType()).ToList() : Enumerable.Empty<Type>())
+        {
+        }
+
+        public InMemoryDataReader(IEnumerable<Dictionary<string, object>> data, IEnumerable<Type> types)
         {
             _data = data.GetEnumerator();
             _originData = data;
             if (_originData.Count() > 0)
             {
                 _keys = _originData.First().Keys.ToList();
-                _types = _originData.First().Values.Select(p => p.GetType()).ToList();
+                _types = types.ToList();
                 _fieldCount = _originData.First().Count;
             }
         }

--- a/tests/Kros.KORM.UnitTests/Helper/TypeExtensionsShould.cs
+++ b/tests/Kros.KORM.UnitTests/Helper/TypeExtensionsShould.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using Xunit;
+﻿using FluentAssertions;
 using Kros.KORM.Helper;
-using FluentAssertions;
+using System;
+using Xunit;
 
 namespace Kros.KORM.UnitTests.Helper
 {
@@ -81,10 +81,10 @@ namespace Kros.KORM.UnitTests.Helper
             public string LastName { get; init; }
 
             public BarRecordWithMoreCtors(string firstName)
-              => (FirstName, LastName) = (firstName, string.Empty);
+                => (FirstName, LastName) = (firstName, string.Empty);
 
             public BarRecordWithMoreCtors(string firstName, string lastName)
-              => (FirstName, LastName) = (firstName, lastName);
+                => (FirstName, LastName) = (firstName, lastName);
         }
     }
 }

--- a/tests/Kros.KORM.UnitTests/Helper/TypeExtensionsShould.cs
+++ b/tests/Kros.KORM.UnitTests/Helper/TypeExtensionsShould.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Xunit;
+using Kros.KORM.Helper;
+using FluentAssertions;
+
+namespace Kros.KORM.UnitTests.Helper
+{
+    public class TypeExtensionsShould
+    {
+        [Theory]
+        [InlineData(typeof(FooWithImplicitDefaultCtor), true, true)]
+        [InlineData(typeof(FooWithExplicitDefaultCtor), true, true)]
+        [InlineData(typeof(FooWithPrivateDefaultCtor), true, true)]
+        [InlineData(typeof(FooWithOneDefaultCtorAndOneAnother), true, true)]
+        [InlineData(typeof(FooWithoutDefaultCtor), true, false)]
+        [InlineData(typeof(BarRecord), true, false)]
+        [InlineData(typeof(BarRecordWithMoreCtors), false, false)]
+        public void ShouldGetConstructor(Type type, bool hasCtor, bool isDefault)
+        {
+            (System.Reflection.ConstructorInfo ctor, bool isDefault) info = type.GetConstructor();
+            info.isDefault.Should().Be(isDefault);
+            if (hasCtor)
+            {
+                info.ctor.Should().NotBeNull();
+            }
+            else
+            {
+                info.ctor.Should().BeNull();
+            }
+
+            if (hasCtor && info.isDefault)
+            {
+                info.ctor.GetParameters().Should().BeEmpty();
+            }
+        }
+
+        public class FooWithImplicitDefaultCtor
+        {
+        }
+
+        public class FooWithExplicitDefaultCtor
+        {
+            public FooWithExplicitDefaultCtor()
+            {
+            }
+        }
+
+        public class FooWithPrivateDefaultCtor
+        {
+            private FooWithPrivateDefaultCtor()
+            {
+            }
+        }
+
+        public class FooWithOneDefaultCtorAndOneAnother
+        {
+            public FooWithOneDefaultCtorAndOneAnother()
+            {
+            }
+#pragma warning disable IDE0060 // Remove unused parameter
+            public FooWithOneDefaultCtorAndOneAnother(int i)
+#pragma warning restore IDE0060 // Remove unused parameter
+            {
+            }
+        }
+
+        public class FooWithoutDefaultCtor
+        {
+#pragma warning disable IDE0060 // Remove unused parameter
+            public FooWithoutDefaultCtor(int i)
+#pragma warning restore IDE0060 // Remove unused parameter
+            {
+            }
+        }
+
+        public record BarRecord(int Id);
+
+        public record BarRecordWithMoreCtors
+        {
+            public string FirstName { get; init; }
+            public string LastName { get; init; }
+
+            public BarRecordWithMoreCtors(string firstName)
+              => (FirstName, LastName) = (firstName, string.Empty);
+
+            public BarRecordWithMoreCtors(string firstName, string lastName)
+              => (FirstName, LastName) = (firstName, lastName);
+        }
+    }
+}

--- a/tests/Kros.KORM.UnitTests/Kros.KORM.UnitTests.csproj
+++ b/tests/Kros.KORM.UnitTests/Kros.KORM.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
     <IsPackable>false</IsPackable>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
@@ -88,6 +88,9 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <None Update="appsettings.local.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -105,4 +108,8 @@
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="if exist &quot;$(ProjectDir)appsettings.local.json&quot; (&#xD;&#xA;  copy &quot;$(ProjectDir)appsettings.local.json&quot; &quot;$(TargetDir)&quot;&#xD;&#xA;)" />
   </Target>
+
+  <PropertyGroup >
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
 </Project>

--- a/tests/Kros.KORM.UnitTests/Materializer/MethodModelFactoryForRecordShould.cs
+++ b/tests/Kros.KORM.UnitTests/Materializer/MethodModelFactoryForRecordShould.cs
@@ -1,0 +1,276 @@
+﻿using FluentAssertions;
+using Kros.KORM.Converter;
+using Kros.KORM.Helper;
+using Kros.KORM.Injection;
+using Kros.KORM.Materializer;
+using Kros.KORM.Metadata;
+using Kros.KORM.Metadata.Attribute;
+using Kros.KORM.UnitTests.Helper;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Kros.KORM.UnitTests.Materializer
+{
+    public class MethodModelFactoryForRecordShould
+    {
+        // injection
+        // CallOnAfterMaterialize
+        // Value Generator
+        // co ked reader nemal field?
+
+        [Fact]
+        public void ShouldUseNameMapping()
+        {
+            IDataReader data = DataBuilder.Create(("Id", typeof(int)), ("FirstName", typeof(string)), ("Payment", typeof(string)))
+                    .AddRow(22, "Foo", 120.5)
+                    .Build();
+            Func<IDataReader, FooWithDifferentPropertyNames> factory = GetFactory<FooWithDifferentPropertyNames>(data);
+
+            data.Read();
+
+            FooWithDifferentPropertyNames foo = factory(data);
+
+            foo.Id.Should().Be(22);
+            foo.Name.Should().Be("Foo");
+            foo.Salary.Should().Be(120.5);
+        }
+
+        [Theory()]
+        [InlineData(23, "Foo", 25.5, 1900.7, "5.4.1998", true, "{371D1F1E-57EA-4D1B-8101-3E8113AE229F}", Gender.Woman, 0.9, "30.3.2021")]
+        [InlineData(26, "Bar", 27.0, null, "5.4.1998", false, "{07C39646-2929-4472-8BB2-FF0197330D24}", Gender.Woman, 1.9, "30.3.2021")]
+        [InlineData(29, "FooBar", 0.5, 19000.74, "5.4.1998", true, "{0F7667BA-9795-4A32-A1FB-97D0F8353F58}", Gender.Man, 3.10, "30.3.2021")]
+        [InlineData(13, "BarFoo", (double)0, 0.0, "5.4.1998", false, "{1462BD2A-3268-41AA-AB4F-C6DBD3264DB2}", Gender.Man, 20.0, "30.3.2021")]
+        public void ShouldReadDifferentTypes(
+            int id,
+            string name,
+            double age,
+            double? salary,
+            string dayOfBirth,
+            bool isEmployed,
+            string tenantId,
+            Gender gender,
+            float floatValue,
+            string changedDate)
+        {
+            IDataReader data = DataBuilder.Create(("Id", typeof(int)), ("Name", typeof(string)), ("Age", typeof(double)),
+                ("Salary", typeof(decimal?)), ("DayOfBirth", typeof(DateTime)), ("IsEmployed", typeof(bool)),
+                ("TenantId", typeof(Guid)), ("Gender", typeof(Gender)), ("FloatValue", typeof(float)),
+                ("ChangedDate", typeof(DateTimeOffset)))
+                .AddRow(id, name, age, (decimal?)salary, dayOfBirth.ParseDateTime(), isEmployed,
+                    Guid.Parse(tenantId), gender, floatValue, new DateTimeOffset(changedDate.ParseDateTime()))
+                .Build();
+            Func<IDataReader, FooWithDifferentTypes> factory = GetFactory<FooWithDifferentTypes>(data);
+
+            data.Read();
+
+            FooWithDifferentTypes bar = factory(data);
+
+            bar.Id.Should().Be(id);
+            bar.Name.Should().Be(name);
+            bar.Age.Should().Be(age);
+            bar.Salary.Should().Be((decimal?)salary);
+            bar.DayOfBirth.Should().BeSameDateAs(dayOfBirth.ParseDateTime());
+            bar.IsEmployed.Should().Be(isEmployed);
+            bar.TenantId.Should().Be(tenantId);
+            bar.Gender.Should().Be(gender);
+            bar.FloatValue.Should().Be(floatValue);
+            bar.ChangedDate.Should().BeSameDateAs(changedDate.ParseDateTime());
+        }
+
+        [Theory()]
+        [InlineData(23, (int)Gender.Woman, 2356)]
+        [InlineData(26, (int)Gender.Man, 4258)]
+        public void ShouldReadTypeWithDefaultConversions(long id, int gender, int salary)
+        {
+            IDataReader data = DataBuilder.Create(("Id", typeof(long)),
+                ("Gender", typeof(int)), ("Salary", typeof(int)))
+                .AddRow(id, gender, salary)
+                .Build();
+            Func<IDataReader, FooWithDefaultConversion> factory = GetFactory<FooWithDefaultConversion>(data);
+
+            data.Read();
+
+            FooWithDefaultConversion bar = factory(data);
+
+            bar.Id.Should().Be(id);
+            bar.Salary.Should().Be(salary);
+            bar.Gender.Should().Be(gender);
+        }
+
+        [Theory()]
+        [InlineData("M", "{07C39646-2929-4472-8BB2-FF0197330D24}")]
+        [InlineData("W", "{1462BD2A-3268-41AA-AB4F-C6DBD3264DB2}")]
+        public void ShouldReadTypeWithCustomConverters(string gender, string tenantId)
+        {
+            var converter = new CustomConverter();
+            IDataReader data = DataBuilder.Create(("Gender", typeof(string)), ("TenantId", typeof(Guid)))
+                .AddRow(gender, new Guid(tenantId))
+                .Build();
+            Func<IDataReader, FooWithConverters> factory = GetFactory<FooWithConverters>(data);
+
+            data.Read();
+
+            FooWithConverters bar = factory(data);
+
+            bar.TenantId.Should().BeEquivalentTo(tenantId);
+            bar.Gender.Should().Be(converter.Convert(gender));
+        }
+
+        [Fact()]
+        public void ShouldReadTypeWithInjectableProperty()
+        {
+            IDataReader data = DataBuilder.Create(("Id", typeof(long)))
+                .AddRow((long)11)
+                .Build();
+            Func<IDataReader, FooWithInjectableProperty> factory = GetFactory<FooWithInjectableProperty>(data);
+
+            data.Read();
+
+            FooWithInjectableProperty bar = factory(data);
+
+            bar.Id.Should().Be(11);
+            bar.Service.Should().NotBeNull();
+            bar.Service.GetValue().Should().Be(22);
+        }
+
+        [Theory()]
+        [InlineData(1, 11)]
+        [InlineData(2, 22)]
+        public void ShouldReadTypeWithIMaterializeInterface(long id, int value)
+        {
+            IDataReader data = DataBuilder.Create(("Id", typeof(long)), ("Value", typeof(int)))
+                .AddRow(id, value)
+                .Build();
+            Func<IDataReader, FooWithOnAfterMaterialize> factory = GetFactory<FooWithOnAfterMaterialize>(data);
+
+            data.Read();
+
+            FooWithOnAfterMaterialize bar = factory(data);
+
+            bar.Id.Should().Be(id);
+            bar.Value.Should().Be(value);
+        }
+
+        public record FooWithDifferentPropertyNames(int Id, [property: Alias("FirstName")] string Name, double Salary);
+
+        public record FooWithDifferentTypes(int Id, string Name, double Age, decimal? Salary, DateTime DayOfBirth,
+            bool IsEmployed, Guid TenantId, Gender Gender, float FloatValue, DateTimeOffset ChangedDate);
+
+        public record FooWithDefaultConversion(long Id, Gender Gender, double Salary);
+
+        public record FooWithConverters([property: Converter(typeof(CustomConverter))] Gender Gender, string TenantId);
+
+        public record FooWithInjectableProperty(long Id, IService Service);
+
+        public record FooWithOnAfterMaterialize(long Id) : IMaterialize
+        {
+            public int Value { get; set; }
+
+            public void OnAfterMaterialize(IDataRecord source)
+                => Value = source.GetInt32(source.GetOrdinal("Value"));
+        };
+
+        #region Helpers
+
+        public interface IService
+        {
+            int GetValue();
+        }
+
+        public class Service : IService
+        {
+            public int GetValue() => 22;
+        }
+
+        public class CustomConverter : IConverter
+        {
+            public object Convert(object value) => value.ToString() switch
+            {
+                "M" => Gender.Man,
+                "V" => Gender.Woman,
+                _ => Gender.None
+            };
+
+            public object ConvertBack(object value) => throw new NotImplementedException();
+        }
+
+        private static Func<IDataReader, T> GetFactory<T>(IDataReader dataReader)
+        {
+            (TableInfo tableInfo, IInjector injector) = GetTableInfo<T>();
+
+            (ConstructorInfo ctor, bool _) = typeof(T).GetConstructor();
+
+            return RecordModelFactory.CreateFactoryForRecords<T>(dataReader, tableInfo, injector, ctor);
+        }
+
+        private static (TableInfo table, IInjector injector) GetTableInfo<T>()
+        {
+            var modelBuilder = new ModelConfigurationBuilder();
+            var modelMapper = new ConventionModelMapper();
+
+            modelBuilder.Entity<FooWithDifferentPropertyNames>()
+                .Property(p => p.Salary).HasColumnName("Payment");
+
+            modelBuilder.Entity<FooWithConverters>()
+                .Property(p => p.TenantId).UseConverter<GuidToStringConverter>();
+
+            modelBuilder.Entity<FooWithInjectableProperty>()
+                .Property(p => p.Service).InjectValue(() => new Service());
+
+            modelBuilder.Build(modelMapper);
+
+
+            return (modelMapper.GetTableInfo<T>(), modelMapper.GetInjector<T>());
+        }
+
+        private class DataBuilder
+        {
+            private readonly (string name, Type type)[] _names;
+            private readonly List<object[]> _values = new List<object[]>();
+
+            public DataBuilder(params (string name, Type type)[] names)
+            {
+                _names = names;
+            }
+
+            public DataBuilder AddRow(params object[] values)
+            {
+                _values.Add(values);
+                return this;
+            }
+
+            public IDataReader Build()
+            {
+                var data = new List<Dictionary<string, object>>();
+                foreach (object[] values in _values)
+                {
+                    var row = new Dictionary<string, object>();
+                    for (int i = 0; i < _names.Length; i++)
+                    {
+                        row.Add(_names[i].name, values[i]);
+                    }
+                    data.Add(row);
+                }
+
+                return new InMemoryDataReader(data, _names.Select(p => p.type));
+            }
+
+            public static DataBuilder Create(params (string name, Type type)[] names)
+                => new DataBuilder(names);
+        }
+
+        public enum Gender
+        {
+            None,
+            Man,
+            Woman
+        }
+
+        #endregion
+    }
+}

--- a/tests/Kros.KORM.UnitTests/Materializer/MethodModelFactoryForRecordShould.cs
+++ b/tests/Kros.KORM.UnitTests/Materializer/MethodModelFactoryForRecordShould.cs
@@ -167,7 +167,7 @@ namespace Kros.KORM.UnitTests.Materializer
 
             public void OnAfterMaterialize(IDataRecord source)
                 => Value = source.GetInt32(source.GetOrdinal("Value"));
-        };
+        }
 
         public interface IService
         {
@@ -224,7 +224,6 @@ namespace Kros.KORM.UnitTests.Materializer
                 .Property(p => p.Service).InjectValue(() => new Service());
 
             modelBuilder.Build(modelMapper);
-
 
             return (modelMapper.GetTableInfo<T>(), modelMapper.GetInjector<T>());
         }

--- a/tests/Kros.KORM.UnitTests/Materializer/MethodModelFactoryForRecordShould.cs
+++ b/tests/Kros.KORM.UnitTests/Materializer/MethodModelFactoryForRecordShould.cs
@@ -9,7 +9,6 @@ using Kros.KORM.UnitTests.Helper;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Xunit;
@@ -18,11 +17,6 @@ namespace Kros.KORM.UnitTests.Materializer
 {
     public class MethodModelFactoryForRecordShould
     {
-        // injection
-        // CallOnAfterMaterialize
-        // Value Generator
-        // co ked reader nemal field?
-
         [Fact]
         public void ShouldUseNameMapping()
         {
@@ -175,8 +169,6 @@ namespace Kros.KORM.UnitTests.Materializer
                 => Value = source.GetInt32(source.GetOrdinal("Value"));
         };
 
-        #region Helpers
-
         public interface IService
         {
             int GetValue();
@@ -198,6 +190,15 @@ namespace Kros.KORM.UnitTests.Materializer
 
             public object ConvertBack(object value) => throw new NotImplementedException();
         }
+
+        public enum Gender
+        {
+            None,
+            Man,
+            Woman
+        }
+
+        #region Helpers
 
         private static Func<IDataReader, T> GetFactory<T>(IDataReader dataReader)
         {
@@ -262,13 +263,6 @@ namespace Kros.KORM.UnitTests.Materializer
 
             public static DataBuilder Create(params (string name, Type type)[] names)
                 => new DataBuilder(names);
-        }
-
-        public enum Gender
-        {
-            None,
-            Man,
-            Woman
         }
 
         #endregion

--- a/tests/Kros.KORM.VB.UnitTests/Kros.KORM.VB.UnitTests.vbproj
+++ b/tests/Kros.KORM.VB.UnitTests/Kros.KORM.VB.UnitTests.vbproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5</TargetFramework>
     <IsPackable>false</IsPackable>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>


### PR DESCRIPTION
I supported `record` type. *(ok, it's not just for the `record` type, because there is nothing like `record` for the runtime. This also applies to classes with one parameter constructor)*.

```csharp
public record Person(int Id, string FirstName, string LastName);

using var database = new Database(new SqlConnection("connection string"));

foreach (Person person = database.Query<Person>())
{
    Console.WriteLine($"{person.Id}: {person.FirstName} - {person.LastName}");
}
```

The same features as for "standard" `class`-es are supported. Converters, name mapping and value injection. It is possible to use fluent notation, but also using attributes.

To use attribute notation, you must use syntax with `property:` keyword.

```csharp
public record Person(int Id, [property: Alias("FirstName")]string Name);
```

Materializing `record` types is a bit faster than with property-filled classes.

1000 rows of `InMemoryDbReader`:

| Method | Mean | Error | StdDev |
|----|----|----|----|
|RecordTypes|301.5 us | 5.07 us | 7.11 us|
|ClassTypes|458.1 us | 7.13 us | 6.68 us|

---

Lots of code around `ILGenerator` was moved to `ILGeneratorHelper`. An internal `RecordModelFactory` class has been created for the code around the materialization of `record` types. *(For easier testing)*.