### PR TITLE
Support explicit ID generator name for primary key

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,14 +510,43 @@ Support two types of generating:
 
 1. Custom
 
-Primary key must be simple `Int32` column. Primary key property in POCO class must be decorated by `Key` attribute and its property `AutoIncrementMethodType` must be set to `Custom`.
+KORM supports 'Int32' and 'Int64' generators. Primary key property in POCO class must be decorated by `Key` attribute
+and its property `AutoIncrementMethodType` must be set to `Custom`.
 
 ```CSharp
-[Key(autoIncrementMethodType: AutoIncrementMethodType.Custom)]
-public int Id { get; set; }
+public class User
+{
+    [Key(autoIncrementMethodType: AutoIncrementMethodType.Custom)]
+    public int Id { get; set; }
+}
 ```
 
-Kros.KORM generates primary key for every inserted record, that does not have value for primary key property. For generating primary keys implementations of [IIdGenerator](https://kros-sk.github.io/Kros.Libs.Documentation/api/Kros.Utils/Kros.Data.IIdGenerator.html) are used.
+Kros.KORM generates primary key for every inserted record, that does not have value for primary key property.
+For generating primary keys implementations of [IIdGenerator](https://kros-sk.github.io/Kros.Libs.Documentation/api/Kros.Utils/Kros.Data.IIdGenerator.html)
+are used.
+
+The names of internal generators are the same as table names, for which the values are generated. But this can be explicitly
+set to some other name. It can be used for example when one generated sequence of numbers need to be used in two tables.
+
+```CSharp
+public class User
+{
+    [Key(autoIncrementMethodType: AutoIncrementMethodType.Custom, generatorName: "CustomGeneratorName")]
+    public int Id { get; set; }
+}
+
+// Or using fluent database configuration.
+
+public class DatabaseConfiguration : DatabaseConfigurationBase
+{
+    public override void OnModelCreating(ModelConfigurationBuilder modelBuilder)
+    {
+        modelBuilder.Entity<User>()
+            .HasPrimaryKey(entity => entity.Id).AutoIncrement(AutoIncrementMethodType.Custom, "CustomGeneratorName");
+    }
+}
+```
+
 
 2. Identity
 

--- a/src/Metadata/Attribute/AliasAttribute.cs
+++ b/src/Metadata/Attribute/AliasAttribute.cs
@@ -14,7 +14,7 @@ namespace Kros.KORM.Metadata.Attribute
         /// </summary>
         /// <param name="alias">The database alias.</param>
         /// <exception cref="ArgumentNullException">The value of <paramref name="alias"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentException">The value of <paramref name="alias"/> is empty string, or stirng
+        /// <exception cref="ArgumentException">The value of <paramref name="alias"/> is empty string, or string
         /// containing whitespace characters only.</exception>
         public AliasAttribute(string alias)
         {

--- a/src/Metadata/Attribute/KeyAttribute.cs
+++ b/src/Metadata/Attribute/KeyAttribute.cs
@@ -12,7 +12,7 @@ namespace Kros.KORM.Metadata.Attribute
         /// Initializes a new instance of the <see cref="KeyAttribute"/> class.
         /// </summary>
         public KeyAttribute()
-            : this(null, AutoIncrementMethodType.None)
+            : this(null, 0, AutoIncrementMethodType.None, null)
         {
         }
 
@@ -21,7 +21,7 @@ namespace Kros.KORM.Metadata.Attribute
         /// </summary>
         /// <param name="order">The order of the column in composite primary key.</param>
         public KeyAttribute(int order)
-            : this(null, order, AutoIncrementMethodType.None)
+            : this(null, order, AutoIncrementMethodType.None, null)
         {
         }
 
@@ -30,7 +30,7 @@ namespace Kros.KORM.Metadata.Attribute
         /// </summary>
         /// <param name="name">The key name.</param>
         public KeyAttribute(string name)
-            : this(name, 0, AutoIncrementMethodType.None)
+            : this(name, 0, AutoIncrementMethodType.None, null)
         {
         }
 
@@ -40,7 +40,7 @@ namespace Kros.KORM.Metadata.Attribute
         /// <param name="name">The key name.</param>
         /// <param name="order">The order of the column in composite primary key.</param>
         public KeyAttribute(string name, int order)
-            : this(name, order, AutoIncrementMethodType.None)
+            : this(name, order, AutoIncrementMethodType.None, null)
         {
         }
 
@@ -49,7 +49,17 @@ namespace Kros.KORM.Metadata.Attribute
         /// </summary>
         /// <param name="autoIncrementMethodType">Type of primary key auto increment method.</param>
         public KeyAttribute(AutoIncrementMethodType autoIncrementMethodType)
-            : this(null, 0, autoIncrementMethodType)
+            : this(null, 0, autoIncrementMethodType, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyAttribute"/> class.
+        /// </summary>
+        /// <param name="autoIncrementMethodType">Type of primary key auto increment method.</param>
+        /// <param name="generatorName">Name of the value generator. If not set, table name will be used.</param>
+        public KeyAttribute(AutoIncrementMethodType autoIncrementMethodType, string generatorName)
+            : this(null, 0, autoIncrementMethodType, generatorName)
         {
         }
 
@@ -59,7 +69,7 @@ namespace Kros.KORM.Metadata.Attribute
         /// <param name="name">The key name.</param>
         /// <param name="autoIncrementMethodType">Type of primary key auto increment method.</param>
         public KeyAttribute(string name, AutoIncrementMethodType autoIncrementMethodType)
-            : this (name, 0, autoIncrementMethodType)
+            : this(name, 0, autoIncrementMethodType, null)
         {
         }
 
@@ -67,11 +77,17 @@ namespace Kros.KORM.Metadata.Attribute
         /// Initializes a new instance of the <see cref="KeyAttribute"/> class.
         /// </summary>
         /// <param name="name">The key name.</param>
-        /// <param name="order">The order of the column in composite primary key.</param>
         /// <param name="autoIncrementMethodType">Type of primary key auto increment method.</param>
-        private KeyAttribute(string name, int order, AutoIncrementMethodType autoIncrementMethodType)
+        /// <param name="generatorName">Name of the value generator. If not set, table name will be used.</param>
+        public KeyAttribute(string name, AutoIncrementMethodType autoIncrementMethodType, string generatorName)
+            : this(name, 0, autoIncrementMethodType, generatorName)
+        {
+        }
+
+        private KeyAttribute(string name, int order, AutoIncrementMethodType autoIncrementMethodType, string generatorName)
         {
             AutoIncrementMethodType = autoIncrementMethodType;
+            GeneratorName = generatorName;
             Name = name;
             Order = order;
         }
@@ -79,7 +95,13 @@ namespace Kros.KORM.Metadata.Attribute
         /// <summary>
         /// Type of primary key auto increment method.
         /// </summary>
-        public AutoIncrementMethodType AutoIncrementMethodType { get; private set; }
+        public AutoIncrementMethodType AutoIncrementMethodType { get; }
+
+        /// <summary>
+        /// Name of the generator when <see cref="AutoIncrementMethodType"/> is <c>Custom</c>.
+        /// If not set, table name will be used.
+        /// </summary>
+        public string GeneratorName { get; }
 
         /// <summary>
         /// The order of the column in composite primary key.

--- a/src/Metadata/ColumnInfo.cs
+++ b/src/Metadata/ColumnInfo.cs
@@ -73,6 +73,11 @@ namespace Kros.KORM.Metadata
         public int PrimaryKeyOrder { get; set; }
 
         /// <summary>
+        /// Name of the generator. If not set, table name will be used.
+        /// </summary>
+        public string GeneratorName { get; set; }
+
+        /// <summary>
         /// Type of primary key auto increment method.
         /// </summary>
         public AutoIncrementMethodType AutoIncrementMethodType { get; set; } = AutoIncrementMethodType.None;

--- a/src/Metadata/ColumnInfo.cs
+++ b/src/Metadata/ColumnInfo.cs
@@ -75,7 +75,7 @@ namespace Kros.KORM.Metadata
         /// <summary>
         /// Name of the generator. If not set, table name will be used.
         /// </summary>
-        public string GeneratorName { get; set; }
+        public string AutoIncrementGeneratorName { get; set; }
 
         /// <summary>
         /// Type of primary key auto increment method.

--- a/src/Metadata/ConventionModelMapper.NestedTypes.cs
+++ b/src/Metadata/ConventionModelMapper.NestedTypes.cs
@@ -26,6 +26,7 @@ namespace Kros.KORM.Metadata
             public string TableName { get; set; } = null;
             public string PrimaryKeyPropertyName { get; set; } = null;
             public AutoIncrementMethodType PrimaryKeyAutoIncrementType { get; set; } = AutoIncrementMethodType.None;
+            public string PrimaryKeyGeneratorName { get; set; } = null;
             public Dictionary<string, string> ColumnMap { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             public Dictionary<string, IConverter> Converters { get; } = new Dictionary<string, IConverter>(StringComparer.OrdinalIgnoreCase);
             public Dictionary<string, IValueGenerator> ValueGenerators { get; } =

--- a/src/Metadata/ConventionModelMapper.cs
+++ b/src/Metadata/ConventionModelMapper.cs
@@ -186,6 +186,7 @@ namespace Kros.KORM.Metadata
                 ColumnInfo columnInfo = tableInfo.GetColumnInfoByPropertyName(entity.PrimaryKeyPropertyName);
                 columnInfo.IsPrimaryKey = true;
                 columnInfo.AutoIncrementMethodType = entity.PrimaryKeyAutoIncrementType;
+                columnInfo.AutoIncrementGeneratorName = entity.PrimaryKeyGeneratorName;
             }
             else
             {
@@ -337,7 +338,7 @@ namespace Kros.KORM.Metadata
                 CheckGeneratorName(tableInfo.Name, pkByAttributes[0].Column, pkByAttributes[0].Attribute);
                 ret.Add(pkByAttributes[0].Column);
                 ret[0].AutoIncrementMethodType = pkByAttributes[0].Attribute.AutoIncrementMethodType;
-                ret[0].GeneratorName = pkByAttributes[0].Attribute.GeneratorName;
+                ret[0].AutoIncrementGeneratorName = pkByAttributes[0].Attribute.GeneratorName;
             }
             else if (pkByAttributes.Count > 1)
             {
@@ -467,11 +468,15 @@ namespace Kros.KORM.Metadata
 
         void IModelMapperInternal.SetInjector<TEntity>(IInjector injector) => GetEntity<TEntity>().Injector = injector;
 
-        void IModelMapperInternal.SetPrimaryKey<TEntity>(string propertyName, AutoIncrementMethodType autoIncrementType)
+        void IModelMapperInternal.SetPrimaryKey<TEntity>(
+            string propertyName,
+            AutoIncrementMethodType autoIncrementType,
+            string generatorName)
         {
             EntityMapper entity = GetEntity<TEntity>();
             entity.PrimaryKeyPropertyName = propertyName;
             entity.PrimaryKeyAutoIncrementType = autoIncrementType;
+            entity.PrimaryKeyGeneratorName = generatorName;
         }
 
         void IModelMapperInternal.SetQueryFilter(string tableName, Expression queryFilter)

--- a/src/Metadata/ConventionModelMapper.cs
+++ b/src/Metadata/ConventionModelMapper.cs
@@ -334,8 +334,10 @@ namespace Kros.KORM.Metadata
             var ret = new List<ColumnInfo>();
             if (pkByAttributes.Count == 1)
             {
+                CheckGeneratorName(tableInfo.Name, pkByAttributes[0].Column, pkByAttributes[0].Attribute);
                 ret.Add(pkByAttributes[0].Column);
                 ret[0].AutoIncrementMethodType = pkByAttributes[0].Attribute.AutoIncrementMethodType;
+                ret[0].GeneratorName = pkByAttributes[0].Attribute.GeneratorName;
             }
             else if (pkByAttributes.Count > 1)
             {
@@ -353,6 +355,17 @@ namespace Kros.KORM.Metadata
             }
 
             return ret;
+        }
+
+        private static void CheckGeneratorName(string tableName, ColumnInfo column, KeyAttribute keyInfo)
+        {
+            if (!string.IsNullOrEmpty(keyInfo.GeneratorName)
+                && (keyInfo.AutoIncrementMethodType != AutoIncrementMethodType.Custom))
+            {
+                throw new InvalidOperationException(
+                    string.Format(Resources.Error_GeneratorNameCanBeSetOnlyWithCustomAutoIncrementType,
+                    tableName, column.Name, keyInfo.GeneratorName, keyInfo.AutoIncrementMethodType));
+            }
         }
 
         private static void CheckPrimaryKeyColumns(

--- a/src/Metadata/FluentConfiguration/EntityTypeBuilder.cs
+++ b/src/Metadata/FluentConfiguration/EntityTypeBuilder.cs
@@ -15,6 +15,7 @@ namespace Kros.KORM.Metadata
         private string _tableName;
         private string _primaryKeyPropertyName;
         private AutoIncrementMethodType _autoIncrementType = AutoIncrementMethodType.None;
+        private string _generatorName = null;
         private readonly Dictionary<Type, IConverter> _propertyConverters = new Dictionary<Type, IConverter>();
         private readonly Dictionary<string, PropertyBuilder<TEntity>> _propertyBuilders
             = new Dictionary<string, PropertyBuilder<TEntity>>(StringComparer.OrdinalIgnoreCase);
@@ -36,6 +37,14 @@ namespace Kros.KORM.Metadata
         IEntityTypeConvertersBuilder<TEntity> IPrimaryKeyBuilder<TEntity>.AutoIncrement(AutoIncrementMethodType autoIncrementType)
         {
             _autoIncrementType = autoIncrementType;
+            return this;
+        }
+
+        IEntityTypeConvertersBuilder<TEntity> IPrimaryKeyBuilder<TEntity>.AutoIncrement(
+            AutoIncrementMethodType autoIncrementType, string generatoraName)
+        {
+            _autoIncrementType = autoIncrementType;
+            _generatorName = generatoraName;
             return this;
         }
 
@@ -77,7 +86,7 @@ namespace Kros.KORM.Metadata
             }
             if (!_primaryKeyPropertyName.IsNullOrWhiteSpace())
             {
-                modelMapper.SetPrimaryKey<TEntity>(_primaryKeyPropertyName, _autoIncrementType);
+                modelMapper.SetPrimaryKey<TEntity>(_primaryKeyPropertyName, _autoIncrementType, _generatorName);
             }
             foreach (KeyValuePair<Type, IConverter> item in _propertyConverters)
             {

--- a/src/Metadata/FluentConfiguration/IModelMapperInternal.cs
+++ b/src/Metadata/FluentConfiguration/IModelMapperInternal.cs
@@ -77,6 +77,10 @@ namespace Kros.KORM.Metadata
         /// <typeparam name="TEntity">Entity type.</typeparam>
         /// <param name="propertyName">Property name, which represent primary key.</param>
         /// <param name="autoIncrementType">Autoincrement method type.</param>
-        void SetPrimaryKey<TEntity>(string propertyName, AutoIncrementMethodType autoIncrementType) where TEntity : class;
+        /// <param name="generatorName">Name of the ID generator for column.</param>
+        void SetPrimaryKey<TEntity>(
+            string propertyName,
+            AutoIncrementMethodType autoIncrementType,
+            string generatorName) where TEntity : class;
     }
 }

--- a/src/Metadata/FluentConfiguration/Interfaces.cs
+++ b/src/Metadata/FluentConfiguration/Interfaces.cs
@@ -93,6 +93,15 @@ namespace Kros.KORM.Metadata
         /// <returns>Returns builder for additional configuration of the entity.</returns>
         IEntityTypeConvertersBuilder<TEntity> AutoIncrement(
             AutoIncrementMethodType autoIncrementType = AutoIncrementMethodType.Identity);
+
+        /// <summary>
+        /// Configures auto-increment type of primary key. If
+        /// </summary>
+        /// <param name="autoIncrementType">Auto-increment type of the primary key. If called without specifying the value,
+        /// <see cref="AutoIncrementMethodType">AutoIncrementMethodType.Identity</see> will be used.</param>
+        /// <param name="generatorName">Name of the ID generator for column.</param>
+        /// <returns>Returns builder for additional configuration of the entity.</returns>
+        IEntityTypeConvertersBuilder<TEntity> AutoIncrement(AutoIncrementMethodType autoIncrementType, string generatorName);
     }
 
     /// <summary>
@@ -233,6 +242,6 @@ namespace Kros.KORM.Metadata
         /// <remarks>
         /// This filter will be used for all entity over this table.
         /// </remarks>
-        void UseQueryFilter<TEntity>(Expression<Func<TEntity, bool>> queryFilter) where TEntity: class;
+        void UseQueryFilter<TEntity>(Expression<Func<TEntity, bool>> queryFilter) where TEntity : class;
     }
 }

--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -205,7 +205,7 @@ namespace Kros.KORM.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Column &apos;{0}.{1}&apos; has generator name &apos;{2}&apos; and auto increment method type &apos;{3}&apos;. Generator name can be set only when auto increment method type&apos; is &apos;Custom&apos;..
+        ///   Looks up a localized string similar to Column &apos;{0}.{1}&apos; has generator name &apos;{2}&apos; and auto increment method type &apos;{3}&apos;. Generator name can be set only when auto increment method type is &apos;Custom&apos;..
         /// </summary>
         internal static string Error_GeneratorNameCanBeSetOnlyWithCustomAutoIncrementType {
             get {

--- a/src/Properties/Resources.Designer.cs
+++ b/src/Properties/Resources.Designer.cs
@@ -205,6 +205,15 @@ namespace Kros.KORM.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Column &apos;{0}.{1}&apos; has generator name &apos;{2}&apos; and auto increment method type &apos;{3}&apos;. Generator name can be set only when auto increment method type&apos; is &apos;Custom&apos;..
+        /// </summary>
+        internal static string Error_GeneratorNameCanBeSetOnlyWithCustomAutoIncrementType {
+            get {
+                return ResourceManager.GetString("Error_GeneratorNameCanBeSetOnlyWithCustomAutoIncrementType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to KORM provider is not set..
         /// </summary>
         internal static string Error_KormProviderNotSet {

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -171,7 +171,7 @@
     <value>Connection string is not set.</value>
   </data>
   <data name="Error_GeneratorNameCanBeSetOnlyWithCustomAutoIncrementType" xml:space="preserve">
-    <value>Column '{0}.{1}' has generator name '{2}' and auto increment method type '{3}'. Generator name can be set only when auto increment method type' is 'Custom'.</value>
+    <value>Column '{0}.{1}' has generator name '{2}' and auto increment method type '{3}'. Generator name can be set only when auto increment method type is 'Custom'.</value>
   </data>
   <data name="Error_KormProviderNotSet" xml:space="preserve">
     <value>KORM provider is not set.</value>

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -170,6 +170,9 @@
   <data name="Error_ConnectionStringNotSet" xml:space="preserve">
     <value>Connection string is not set.</value>
   </data>
+  <data name="Error_GeneratorNameCanBeSetOnlyWithCustomAutoIncrementType" xml:space="preserve">
+    <value>Column '{0}.{1}' has generator name '{2}' and auto increment method type '{3}'. Generator name can be set only when auto increment method type' is 'Custom'.</value>
+  </data>
   <data name="Error_KormProviderNotSet" xml:space="preserve">
     <value>KORM provider is not set.</value>
   </data>

--- a/src/Query/DbSet.cs
+++ b/src/Query/DbSet.cs
@@ -454,7 +454,7 @@ namespace Kros.KORM.Query
             if (CanGeneratePrimaryKeys(out ColumnInfo primaryKey))
             {
                 Type dataType = primaryKey.PropertyInfo.PropertyType;
-                string generatorName = primaryKey.GeneratorName ?? _tableInfo.Name;
+                string generatorName = primaryKey.AutoIncrementGeneratorName ?? _tableInfo.Name;
                 using (var generator = _provider.CreateIdGenerator(dataType, generatorName, items.Count))
                 {
                     foreach (T item in items)
@@ -599,7 +599,7 @@ namespace Kros.KORM.Query
 
                     var idGenerator = CanGeneratePrimaryKeys(out ColumnInfo pkColumn)
                         ? _provider.CreateIdGenerator(pkColumn.PropertyInfo.PropertyType,
-                            pkColumn.GeneratorName ?? _tableInfo.Name, batchSize)
+                            pkColumn.AutoIncrementGeneratorName ?? _tableInfo.Name, batchSize)
                         : null;
 
                     using (var reader = new KormBulkInsertDataReader<T>(items, _commandGenerator, idGenerator, _tableInfo))

--- a/src/Query/DbSet.cs
+++ b/src/Query/DbSet.cs
@@ -454,7 +454,8 @@ namespace Kros.KORM.Query
             if (CanGeneratePrimaryKeys(out ColumnInfo primaryKey))
             {
                 Type dataType = primaryKey.PropertyInfo.PropertyType;
-                using (var generator = _provider.CreateIdGenerator(dataType, _tableInfo.Name, items.Count))
+                string generatorName = primaryKey.GeneratorName ?? _tableInfo.Name;
+                using (var generator = _provider.CreateIdGenerator(dataType, generatorName, items.Count))
                 {
                     foreach (T item in items)
                     {
@@ -597,7 +598,8 @@ namespace Kros.KORM.Query
                     var batchSize = items is ICollection<T> coll ? coll.Count : defaultBatchSize;
 
                     var idGenerator = CanGeneratePrimaryKeys(out ColumnInfo pkColumn)
-                        ? _provider.CreateIdGenerator(pkColumn.PropertyInfo.PropertyType, _tableInfo.Name, batchSize)
+                        ? _provider.CreateIdGenerator(pkColumn.PropertyInfo.PropertyType,
+                            pkColumn.GeneratorName ?? _tableInfo.Name, batchSize)
                         : null;
 
                     using (var reader = new KormBulkInsertDataReader<T>(items, _commandGenerator, idGenerator, _tableInfo))

--- a/tests/Kros.KORM.UnitTests/Integration/DbSetPkGeneratorsTests.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/DbSetPkGeneratorsTests.cs
@@ -1,0 +1,140 @@
+﻿using FluentAssertions;
+using Kros.Data;
+using Kros.KORM.Metadata;
+using Kros.KORM.Metadata.Attribute;
+using Kros.KORM.Query;
+using Kros.KORM.UnitTests.Base;
+using Xunit;
+
+namespace Kros.KORM.UnitTests.Integration
+{
+    public class DbSetPkGeneratorsTests : DatabaseTestBase
+    {
+        #region Helpers
+
+        private const string AbGenerator = "AbGenerator";
+        private const string TestTableNameA = "TestTableA";
+        private const string TestTableNameB = "TestTableB";
+
+        private static readonly string CreateTable_A =
+$@"CREATE TABLE [dbo].[{TestTableNameA}] (
+    [IdA] [int] NOT NULL,
+    [Name] [nvarchar](50) NULL
+) ON [PRIMARY];";
+
+        private static readonly string CreateTable_B =
+$@"CREATE TABLE [dbo].[{TestTableNameB}] (
+    [IdB] [int] NOT NULL,
+    [Name] [nvarchar](50) NULL
+) ON [PRIMARY];";
+
+        [Alias(TestTableNameA)]
+        public class PersonA
+        {
+            [Key(autoIncrementMethodType: AutoIncrementMethodType.Custom, generatorName: AbGenerator)]
+            public int IdA { get; set; }
+            public string Name { get; set; }
+        }
+
+        [Alias(TestTableNameB)]
+        public class PersonB
+        {
+            [Alias("IdB")]
+            [Key(autoIncrementMethodType: AutoIncrementMethodType.Custom, generatorName: AbGenerator)]
+            public int Pk { get; set; }
+            public string Name { get; set; }
+        }
+
+        private TestDatabase CreateTestDatabase()
+        {
+            TestDatabase db = CreateDatabase(new[] { CreateTable_A, CreateTable_B });
+            foreach (IIdGenerator idGenerator in IdGeneratorFactories.GetGeneratorsForDatabaseInit(db.Connection))
+            {
+                idGenerator.InitDatabaseForIdGenerator();
+            }
+            return db;
+        }
+
+        private static void InsertItems<T>(IDbSet<T> set, params T[] items)
+        {
+            foreach (T item in items)
+            {
+                set.Add(item);
+            }
+            set.CommitChanges();
+        }
+
+        #endregion
+
+        [Fact]
+        public void DifferentTablesUseSamePkGenerator_InsertSingleItem()
+        {
+            using TestDatabase db = CreateTestDatabase();
+
+            IDbSet<PersonA> setA = db.Query<PersonA>().AsDbSet();
+            var personA1 = new PersonA { Name = "Alice A" };
+            var personA2 = new PersonA { Name = "Bob A" };
+            var personA3 = new PersonA { Name = "Connor A" };
+
+            IDbSet<PersonB> setB = db.Query<PersonB>().AsDbSet();
+            var personB1 = new PersonB { Name = "Alice B" };
+            var personB2 = new PersonB { Name = "Bob B" };
+            var personB3 = new PersonB { Name = "Connor B" };
+
+            InsertItems(setA, personA1);
+            InsertItems(setB, personB1);
+            InsertItems(setA, personA2);
+            InsertItems(setB, personB2);
+            InsertItems(setA, personA3);
+            InsertItems(setB, personB3);
+
+            personA1.IdA.Should().Be(1);
+            personA2.IdA.Should().Be(3);
+            personA3.IdA.Should().Be(5);
+            personB1.Pk.Should().Be(2);
+            personB2.Pk.Should().Be(4);
+            personB3.Pk.Should().Be(6);
+        }
+
+        [Fact]
+        public void DifferentTablesUseSamePkGenerator_InsertMultipleItems()
+        {
+            using TestDatabase db = CreateTestDatabase();
+
+            IDbSet<PersonA> setA = db.Query<PersonA>().AsDbSet();
+            var personA1 = new PersonA { Name = "Alice A" };
+            var personA2 = new PersonA { Name = "Bob A" };
+            var personA3 = new PersonA { Name = "Connor A" };
+            var personA4 = new PersonA { Name = "Drew A" };
+            var personA5 = new PersonA { Name = "Eve A" };
+            var personA6 = new PersonA { Name = "Fiona A" };
+
+            IDbSet<PersonB> setB = db.Query<PersonB>().AsDbSet();
+            var personB1 = new PersonB { Name = "Alice B" };
+            var personB2 = new PersonB { Name = "Bob B" };
+            var personB3 = new PersonB { Name = "Connor B" };
+            var personB4 = new PersonB { Name = "Drew B" };
+            var personB5 = new PersonB { Name = "Eve B" };
+            var personB6 = new PersonB { Name = "Fiona B" };
+
+            InsertItems(setA, new[] { personA1, personA2, personA3 });
+            InsertItems(setB, new[] { personB1, personB2, personB3 });
+            InsertItems(setA, new[] { personA4, personA5, personA6 });
+            InsertItems(setB, new[] { personB4, personB5, personB6 });
+
+            personA1.IdA.Should().Be(1);
+            personA2.IdA.Should().Be(2);
+            personA3.IdA.Should().Be(3);
+            personA4.IdA.Should().Be(7);
+            personA5.IdA.Should().Be(8);
+            personA6.IdA.Should().Be(9);
+
+            personB1.Pk.Should().Be(4);
+            personB2.Pk.Should().Be(5);
+            personB3.Pk.Should().Be(6);
+            personB4.Pk.Should().Be(10);
+            personB5.Pk.Should().Be(11);
+            personB6.Pk.Should().Be(12);
+        }
+    }
+}

--- a/tests/Kros.KORM.UnitTests/Integration/DbSetPkGeneratorsTests.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/DbSetPkGeneratorsTests.cs
@@ -4,6 +4,7 @@ using Kros.KORM.Metadata;
 using Kros.KORM.Metadata.Attribute;
 using Kros.KORM.Query;
 using Kros.KORM.UnitTests.Base;
+using System;
 using Xunit;
 
 namespace Kros.KORM.UnitTests.Integration
@@ -61,6 +62,13 @@ $@"CREATE TABLE [dbo].[{TestTableNameB}] (
             public string Name { get; set; }
         }
 
+        public class PersonInvalid
+        {
+            [Key(autoIncrementMethodType: AutoIncrementMethodType.Identity, generatorName: TestTableNameA)]
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
         private TestDatabase CreateTestDatabase()
         {
             TestDatabase db = CreateDatabase(new[] { CreateTable_A, CreateTable_B });
@@ -81,6 +89,14 @@ $@"CREATE TABLE [dbo].[{TestTableNameB}] (
         }
 
         #endregion
+
+        [Fact]
+        public void GeneratorNameIsAllowedOnlyWithCustomAutoIncrement()
+        {
+            using TestDatabase db = CreateTestDatabase();
+            Action action = () => { IDbSet<PersonInvalid> setA = db.Query<PersonInvalid>().AsDbSet(); };
+            action.Should().Throw<InvalidOperationException>().WithMessage("*Custom*");
+        }
 
         [Fact]
         public void DifferentTablesUseSamePkGenerator_InsertSingleItem()

--- a/tests/Kros.KORM.UnitTests/Integration/TestDatabase.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/TestDatabase.cs
@@ -1,6 +1,0 @@
-﻿namespace Kros.KORM.UnitTests.Integration
-{
-    internal class TestDatabase
-    {
-    }
-}

--- a/tests/Kros.KORM.UnitTests/Integration/TestDatabase.cs
+++ b/tests/Kros.KORM.UnitTests/Integration/TestDatabase.cs
@@ -1,0 +1,6 @@
+﻿namespace Kros.KORM.UnitTests.Integration
+{
+    internal class TestDatabase
+    {
+    }
+}

--- a/tests/Kros.KORM.UnitTests/Materializer/ModelMapperShould.cs
+++ b/tests/Kros.KORM.UnitTests/Materializer/ModelMapperShould.cs
@@ -272,7 +272,8 @@ namespace Kros.KORM.UnitTests.Metadata
         public void GetTableInfoWithPrimaryKeyFluentDefinition()
         {
             var modelMapper = new ConventionModelMapper();
-            ((IModelMapperInternal)modelMapper).SetPrimaryKey<FluentPrivateKey>("RecordId", AutoIncrementMethodType.Identity);
+            ((IModelMapperInternal)modelMapper)
+                .SetPrimaryKey<FluentPrivateKey>("RecordId", AutoIncrementMethodType.Identity, null);
 
             var tableInfo = modelMapper.GetTableInfo<FluentPrivateKey>();
             tableInfo.PrimaryKey
@@ -280,6 +281,23 @@ namespace Kros.KORM.UnitTests.Metadata
                 .HaveCount(1)
                 .And
                 .ContainSingle((c) => c.Name == "RecordId" && c.AutoIncrementMethodType == AutoIncrementMethodType.Identity);
+        }
+
+        [Fact]
+        public void GetTableInfoWithPrimaryKeyFluentDefinitionWithGeneratorName()
+        {
+            var modelMapper = new ConventionModelMapper();
+            ((IModelMapperInternal)modelMapper)
+                .SetPrimaryKey<FluentPrivateKey>("RecordId", AutoIncrementMethodType.Identity, "LoremIpsum");
+
+            var tableInfo = modelMapper.GetTableInfo<FluentPrivateKey>();
+            tableInfo.PrimaryKey
+                .Should()
+                .HaveCount(1)
+                .And
+                .ContainSingle((c) => c.Name == "RecordId"
+                    && c.AutoIncrementMethodType == AutoIncrementMethodType.Identity
+                    && c.AutoIncrementGeneratorName == "LoremIpsum");
         }
 
         [Fact]


### PR DESCRIPTION
Usually, ID generator name is the name of the table where the items are inserted. But we have a use case, where the same ID generator must be used for two (or more) tables. So we need to explicitly specify generator name for the table.

PR adds property `GeneratorName` to `KeyAttribute`. This generator is used for new IDs. 