### PR TITLE
Fix nullable types

### DIFF
--- a/src/Data/DataReaderExtensions.cs
+++ b/src/Data/DataReaderExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Data;
+
+namespace Kros.KORM.Data
+{
+    internal static class DataReaderExtensions
+    {
+        public static bool? GetNullableBoolean(this IDataReader reader, int i)
+            => reader.IsDBNull(i) ? null : reader.GetBoolean(i);
+
+        public static byte? GetNullableByte(this IDataReader reader, int i)
+            => reader.IsDBNull(i) ? null : reader.GetByte(i);
+
+        public static char? GetNullableChar(this IDataReader reader, int i)
+            => reader.IsDBNull(i) ? null : reader.GetChar(i);
+
+        public static DateTime? GetNullableDateTime(this IDataReader reader, int i)
+            => reader.IsDBNull(i) ? null : reader.GetDateTime(i);
+
+        public static decimal? GetNullableDecimal(this IDataReader reader, int i)
+            => reader.IsDBNull(i) ? null : reader.GetDecimal(i);
+
+        public static double? GetNullableDouble(this IDataReader reader, int i)
+            => reader.IsDBNull(i) ? null : reader.GetDouble(i);
+
+        public static Guid? GetNullableGuid(this IDataReader reader, int i)
+            => reader.IsDBNull(i) ? null : reader.GetGuid(i);
+
+        public static short? GetNullableInt16(this IDataReader reader, int i)
+            => reader.IsDBNull(i) ? null : reader.GetInt16(i);
+
+        public static int? GetNullableInt32(this IDataReader reader, int i)
+            => reader.IsDBNull(i) ? null : reader.GetInt32(i);
+
+        public static long? GetNullableInt64(this IDataReader reader, int i)
+            => reader.IsDBNull(i) ? null : reader.GetInt64(i);
+
+        public static float? GetNullableFloat(this IDataReader reader, int i)
+            => reader.IsDBNull(i) ? null : reader.GetFloat(i);
+    }
+}

--- a/src/Materializer/ILGeneratorHelper.cs
+++ b/src/Materializer/ILGeneratorHelper.cs
@@ -33,12 +33,11 @@ namespace Kros.KORM.Materializer
         public static ILGenerator CallReaderMethod(
             this ILGenerator iLGenerator,
             int fieldIndex,
-            MethodInfo methodInfo,
-            bool asVirtual = true)
+            MethodInfo methodInfo)
         {
             iLGenerator.Emit(OpCodes.Ldarg_0);
             iLGenerator.Emit(OpCodes.Ldc_I4, fieldIndex);
-            iLGenerator.Emit(asVirtual ? OpCodes.Callvirt : OpCodes.Call, methodInfo);
+            iLGenerator.Emit(methodInfo.IsVirtual ? OpCodes.Callvirt : OpCodes.Call, methodInfo);
 
             return iLGenerator;
         }
@@ -90,7 +89,7 @@ namespace Kros.KORM.Materializer
                 throw new InvalidOperationException(
                     Properties.Resources.CannotMaterializeSourceValue.Format(srcType, columnInfo.PropertyInfo.PropertyType));
             }
-            iLGenerator.CallReaderMethod(fieldIndex, valuegetter, !columnInfo.IsNullable || castNeeded);
+            iLGenerator.CallReaderMethod(fieldIndex, valuegetter);
 
             if (castNeeded)
             {

--- a/src/Metadata/ColumnInfo.cs
+++ b/src/Metadata/ColumnInfo.cs
@@ -11,6 +11,7 @@ namespace Kros.KORM.Metadata
     {
         private PropertyInfo _propertyInfo;
         private object _defaultValue;
+        private bool? _isNullable = null;
 
         /// <summary>
         /// Column name.
@@ -97,5 +98,21 @@ namespace Kros.KORM.Metadata
         /// Return value from targetObject.
         /// </returns>
         public object GetValue(object targetObject) => PropertyInfo.GetValue(targetObject, null);
+
+        /// <summary>
+        /// Gets a value indicating whether property has nullable type.
+        /// </summary>
+        public bool IsNullable
+        {
+            get
+            {
+                if (!_isNullable.HasValue)
+                {
+                    _isNullable = Nullable.GetUnderlyingType(PropertyInfo.PropertyType) != null;
+                }
+
+                return _isNullable.Value;
+            }
+        }
     }
 }

--- a/src/Metadata/ColumnInfo.cs
+++ b/src/Metadata/ColumnInfo.cs
@@ -25,6 +25,7 @@ namespace Kros.KORM.Metadata
             set
             {
                 _propertyInfo = value;
+                IsNullable = false;
                 DefaultValue = null;
                 if (_propertyInfo is not null)
                 {

--- a/src/Metadata/ColumnInfo.cs
+++ b/src/Metadata/ColumnInfo.cs
@@ -10,7 +10,6 @@ namespace Kros.KORM.Metadata
     public class ColumnInfo
     {
         private PropertyInfo _propertyInfo;
-        private object _defaultValue;
 
         /// <summary>
         /// Column name.
@@ -26,14 +25,14 @@ namespace Kros.KORM.Metadata
             set
             {
                 _propertyInfo = value;
-                _defaultValue = null;
+                DefaultValue = null;
                 if (_propertyInfo is not null)
                 {
                     IsNullable = Nullable.GetUnderlyingType(PropertyInfo.PropertyType) != null;
-                }
-                if (_propertyInfo is not null && _propertyInfo.PropertyType.IsValueType)
-                {
-                    _defaultValue = Activator.CreateInstance(PropertyInfo.PropertyType);
+                    if (_propertyInfo.PropertyType.IsValueType)
+                    {
+                        DefaultValue = Activator.CreateInstance(PropertyInfo.PropertyType);
+                    }
                 }
             }
         }
@@ -41,7 +40,7 @@ namespace Kros.KORM.Metadata
         /// <summary>
         /// Default value for the data type of the column.
         /// </summary>
-        public object DefaultValue => _defaultValue;
+        public object DefaultValue { get; private set; }
 
         /// <summary>
         /// Checks if <paramref name="value"/> is default value of the column.

--- a/src/Metadata/ColumnInfo.cs
+++ b/src/Metadata/ColumnInfo.cs
@@ -11,7 +11,6 @@ namespace Kros.KORM.Metadata
     {
         private PropertyInfo _propertyInfo;
         private object _defaultValue;
-        private bool? _isNullable = null;
 
         /// <summary>
         /// Column name.
@@ -28,6 +27,10 @@ namespace Kros.KORM.Metadata
             {
                 _propertyInfo = value;
                 _defaultValue = null;
+                if (_propertyInfo is not null)
+                {
+                    IsNullable = Nullable.GetUnderlyingType(PropertyInfo.PropertyType) != null;
+                }
                 if (_propertyInfo is not null && _propertyInfo.PropertyType.IsValueType)
                 {
                     _defaultValue = Activator.CreateInstance(PropertyInfo.PropertyType);
@@ -102,17 +105,6 @@ namespace Kros.KORM.Metadata
         /// <summary>
         /// Gets a value indicating whether property has nullable type.
         /// </summary>
-        public bool IsNullable
-        {
-            get
-            {
-                if (!_isNullable.HasValue)
-                {
-                    _isNullable = Nullable.GetUnderlyingType(PropertyInfo.PropertyType) != null;
-                }
-
-                return _isNullable.Value;
-            }
-        }
+        public bool IsNullable { get; private set; }
     }
 }

--- a/tests/Kros.KORM.UnitTests/Data/DataReaderExtensionsShould.cs
+++ b/tests/Kros.KORM.UnitTests/Data/DataReaderExtensionsShould.cs
@@ -44,12 +44,12 @@ namespace Kros.KORM.UnitTests.Data
         }
 
         [Theory]
-        [InlineData("5.4.2021")]
-        [InlineData("6.3.2020")]
+        [InlineData("2021-04-05")]
+        [InlineData("2020-03-06")]
         [InlineData(null)]
         public void GetNullableDateTime(string value)
         {
-            DateTime? dateTime = value.IsNullOrEmpty() ? null : DateTime.Parse(value);
+            DateTime? dateTime = value.IsNullOrEmpty() ? null : value.ParseDateTime();
             InMemoryDataReader dataReader = CreateReader(dateTime);
 
             dataReader.GetNullableDateTime(0).Should().Be(dateTime);

--- a/tests/Kros.KORM.UnitTests/Data/DataReaderExtensionsShould.cs
+++ b/tests/Kros.KORM.UnitTests/Data/DataReaderExtensionsShould.cs
@@ -1,0 +1,146 @@
+﻿using Castle.Core.Internal;
+using FluentAssertions;
+using Kros.KORM.Data;
+using Kros.KORM.UnitTests.Helper;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Kros.KORM.UnitTests.Data
+{
+    public class DataReaderExtensionsShould
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [InlineData(null)]
+        public void GetNullableBoolean(bool? value)
+        {
+            InMemoryDataReader dataReader = CreateReader(value);
+
+            dataReader.GetNullableBoolean(0).Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData((byte)0)]
+        [InlineData((byte)1)]
+        [InlineData(null)]
+        public void GetNullableByte(byte? value)
+        {
+            InMemoryDataReader dataReader = CreateReader(value);
+
+            dataReader.GetNullableByte(0).Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData('g')]
+        [InlineData('*')]
+        [InlineData(null)]
+        public void GetNullableChar(char? value)
+        {
+            InMemoryDataReader dataReader = CreateReader(value);
+
+            dataReader.GetNullableChar(0).Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("5.4.2021")]
+        [InlineData("6.3.2020")]
+        [InlineData(null)]
+        public void GetNullableDateTime(string value)
+        {
+            DateTime? dateTime = value.IsNullOrEmpty() ? null : DateTime.Parse(value);
+            InMemoryDataReader dataReader = CreateReader(dateTime);
+
+            dataReader.GetNullableDateTime(0).Should().Be(dateTime);
+        }
+
+        [Theory]
+        [InlineData(0.45)]
+        [InlineData(22)]
+        [InlineData(null)]
+        public void GetNullableDecimal(double? value)
+        {
+            decimal? d = (decimal?)value;
+            InMemoryDataReader dataReader = CreateReader(d);
+
+            dataReader.GetNullableDecimal(0).Should().Be(d);
+        }
+
+        [Theory]
+        [InlineData(11)]
+        [InlineData(0.785)]
+        [InlineData(null)]
+        public void GetNullableDouble(double? value)
+        {
+            InMemoryDataReader dataReader = CreateReader(value);
+
+            dataReader.GetNullableDouble(0).Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("{3D6F4D25-60E8-432B-B6A7-3ADDBD331812}")]
+        [InlineData("{39AFEC5B-A784-45B5-9233-6488DC1BFB1D}")]
+        [InlineData(null)]
+        public void GetNullableGuid(string value)
+        {
+            Guid? g = value.IsNullOrEmpty() ? null : new Guid(value);
+            InMemoryDataReader dataReader = CreateReader(g);
+
+            dataReader.GetNullableGuid(0).Should().Be(g);
+        }
+
+        [Theory]
+        [InlineData((short)11)]
+        [InlineData((short)33)]
+        [InlineData(null)]
+        public void GetNullableInt16(short? value)
+        {
+            InMemoryDataReader dataReader = CreateReader(value);
+
+            dataReader.GetNullableInt16(0).Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData(22)]
+        [InlineData(44)]
+        [InlineData(null)]
+        public void GetNullableInt32(int? value)
+        {
+            InMemoryDataReader dataReader = CreateReader(value);
+
+            dataReader.GetNullableInt32(0).Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(125)]
+        [InlineData(null)]
+        public void GetNullableInt64(long? value)
+        {
+            InMemoryDataReader dataReader = CreateReader(value);
+
+            dataReader.GetNullableInt64(0).Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(125)]
+        [InlineData(null)]
+        public void GetNullableFloat(float? value)
+        {
+            InMemoryDataReader dataReader = CreateReader(value);
+
+            dataReader.GetNullableFloat(0).Should().Be(value);
+        }
+
+        private static InMemoryDataReader CreateReader<T>(T value)
+        {
+            var dataReader = new InMemoryDataReader(
+                new Dictionary<string, object>[] { new() { { "value", value } } }, new Type[] { typeof(T) });
+            dataReader.Read();
+
+            return dataReader;
+        }
+    }
+}

--- a/tests/Kros.KORM.UnitTests/Helper/DateTimeExtensions.cs
+++ b/tests/Kros.KORM.UnitTests/Helper/DateTimeExtensions.cs
@@ -5,9 +5,7 @@ namespace Kros.KORM.UnitTests.Helper
 {
     internal static class DateTimeExtensions
     {
-        public static CultureInfo _culture = CultureInfo.GetCultureInfo("sk-SK");
-
         public static DateTime ParseDateTime(this string dateTime)
-            => DateTime.Parse(dateTime, _culture);
+            => DateTime.Parse(dateTime, CultureInfo.InvariantCulture);
     }
 }

--- a/tests/Kros.KORM.UnitTests/Materializer/MethodModelFactoryForRecordShould.cs
+++ b/tests/Kros.KORM.UnitTests/Materializer/MethodModelFactoryForRecordShould.cs
@@ -36,10 +36,10 @@ namespace Kros.KORM.UnitTests.Materializer
         }
 
         [Theory()]
-        [InlineData(23, "Foo", 25.5, 1900.7, "5.4.1998", true, "{371D1F1E-57EA-4D1B-8101-3E8113AE229F}", Gender.Woman, 0.9, "30.3.2021")]
-        [InlineData(26, "Bar", 27.0, null, "5.4.1998", false, "{07C39646-2929-4472-8BB2-FF0197330D24}", Gender.Woman, 1.9, "30.3.2021")]
-        [InlineData(29, "FooBar", 0.5, 19000.74, "5.4.1998", true, "{0F7667BA-9795-4A32-A1FB-97D0F8353F58}", Gender.Man, 3.10, "30.3.2021")]
-        [InlineData(13, "BarFoo", (double)0, 0.0, "5.4.1998", false, "{1462BD2A-3268-41AA-AB4F-C6DBD3264DB2}", Gender.Man, 20.0, "30.3.2021")]
+        [InlineData(23, "Foo", 25.5, 1900.7, "1998-04-05", true, "{371D1F1E-57EA-4D1B-8101-3E8113AE229F}", Gender.Woman, 0.9, "2021-03-30")]
+        [InlineData(26, "Bar", 27.0, null, "1998-04-05", false, "{07C39646-2929-4472-8BB2-FF0197330D24}", Gender.Woman, 1.9, "2021-03-30")]
+        [InlineData(29, "FooBar", 0.5, 19000.74, "1998-04-05", true, "{0F7667BA-9795-4A32-A1FB-97D0F8353F58}", Gender.Man, 3.10, "2021-03-30")]
+        [InlineData(13, "BarFoo", (double)0, 0.0, "1998-04-05", false, "{1462BD2A-3268-41AA-AB4F-C6DBD3264DB2}", Gender.Man, 20.0, "2021-03-30")]
         public void ShouldReadDifferentTypes(
             int id,
             string name,
@@ -153,13 +153,13 @@ namespace Kros.KORM.UnitTests.Materializer
 
         [Theory()]
         [InlineData(null, null, null, null, null, null, null, null, null, null)]
-        [InlineData(12, 'c', 32, 12.5, true, (byte)1, "6.2.2020", 56.7, "{3D6F4D25-60E8-432B-B6A7-3ADDBD331812}", (float)58.9)]
-        [InlineData(52, '*', 2, 18.05, false, (byte)0, "8.9.2028", 152.007, "{94FB4F1C-9FEE-457C-84E8-E7562601DC39}", (float)8)]
+        [InlineData(12, 'c', 32, 12.5, true, (byte)1, "2020-02-06", 56.7, "{3D6F4D25-60E8-432B-B6A7-3ADDBD331812}", (float)58.9)]
+        [InlineData(52, '*', 2, 18.05, false, (byte)0, "2028-09-08", 152.007, "{94FB4F1C-9FEE-457C-84E8-E7562601DC39}", (float)8)]
         public void ShouldReadTypeWithNullableTypes(long? longValue, char? charValue, int? intValue, double? decimalValue,
             bool? boolValue, byte? byteValue, string dateTimeValue, double? doubleValue,
             string guidValue, float? floatValue)
         {
-            DateTime? dt = dateTimeValue.IsNullOrEmpty() ? null : DateTime.Parse(dateTimeValue);
+            DateTime? dt = dateTimeValue.IsNullOrEmpty() ? null : dateTimeValue.ParseDateTime();
             Guid? guid = guidValue.IsNullOrEmpty() ? null : new Guid(guidValue);
 
             IDataReader data = DataBuilder.Create(("LongValue", typeof(long)), ("CharValue", typeof(char)),


### PR DESCRIPTION
V prípade `record` typov bol problém pokiaľ tento typ obsahoval nullable hodnoty.

```csharp
public record Foo(int? NullableParameter)
```

Viac príkladov je v [repe od](https://github.com/rudolfficek/Korm.Query.Tests) @rudolfficek. 

Všetky jeho príklady už prechádzajú až na jeden. Prípad, ktorý popisuje test `HaveDataWithNullColumnCorrectlyMapped_MappedAsRecordMutable` je aktuálne zámerne nepodporovaný.

--- 

Oprava bola realizovaná tak, že v prípade, že sa jedná o nullable typ tak sa na získanie hodnoty z `IDataReader` použije naša extension metóda (prislúchajúca k danému dátovému typu)