### PR TITLE
Fixed inserting data with delimiters

### DIFF
--- a/src/CommandGenerator/CommandGenerator.cs
+++ b/src/CommandGenerator/CommandGenerator.cs
@@ -278,7 +278,7 @@ SELECT * FROM @OutputTable;";
 
                 foreach (string column in columns)
                 {
-                    ColumnInfo columnInfo = _tableInfo.Columns.Where(p => p.Name == column.Trim()).FirstOrDefault();
+                    ColumnInfo columnInfo = _tableInfo.GetColumnInfo(column.Trim());
 
                     if (columnInfo != null)
                     {

--- a/src/Kros.KORM.csproj
+++ b/src/Kros.KORM.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
-    <Version>4.3.0</Version>
+    <Version>4.3.1</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>KORM is fast, easy to use, micro ORM tool (Kros Object Relation Mapper).</Description>

--- a/src/Metadata/Delimiters.cs
+++ b/src/Metadata/Delimiters.cs
@@ -14,17 +14,17 @@ namespace Kros.KORM.Metadata
         /// <param name="closing">The closing.</param>
         public Delimiters(string opening, string closing)
         {
-            Openin = Check.NotNull(opening, nameof(opening));
+            Opening = Check.NotNull(opening, nameof(opening));
             Closing = Check.NotNull(closing, nameof(closing));
         }
 
         /// <summary>
-        /// Gets the closing.
+        /// Gets the opening.
         /// </summary>
-        public string Openin { get; }
+        public string Opening { get; }
 
         /// <summary>
-        /// Gets the opening.
+        /// Gets the closing.
         /// </summary>
         public string Closing { get; }
 
@@ -33,7 +33,14 @@ namespace Kros.KORM.Metadata
         /// </summary>
         /// <param name="identifier">The identifier.</param>
         public string QuoteIdentifier(string identifier)
-            => Openin + identifier + Closing;
+            => Opening + identifier + Closing;
+
+        /// <summary>
+        /// Removes the delimiters from identifier.
+        /// </summary>
+        /// <param name="identifier">The identifier.</param>
+        public string RemoveDelimiters(string identifier)
+            => identifier?.TrimStart(Opening.ToCharArray()).TrimEnd(Closing.ToCharArray());
 
         /// <summary>
         /// The square brackets.
@@ -48,6 +55,6 @@ namespace Kros.KORM.Metadata
         /// <summary>
         /// Converts to string.
         /// </summary>
-        public override string ToString() => $"{Openin} {Closing}";
+        public override string ToString() => $"{Opening} {Closing}";
     }
 }

--- a/src/Metadata/TableInfo.cs
+++ b/src/Metadata/TableInfo.cs
@@ -148,7 +148,8 @@ namespace Kros.KORM.Metadata
         public ColumnInfo GetColumnInfo(string columnName)
         {
             Check.NotNull(columnName, nameof(columnName));
-            return _columns.TryGetValue(columnName, out ColumnInfo column) ? column : null;
+            return _columns
+                .TryGetValue(Delimiters.RemoveDelimiters(columnName), out ColumnInfo column) ? column : null;
         }
 
         /// <summary>

--- a/tests/Kros.KORM.UnitTests/Metadata/TableInfoShould.cs
+++ b/tests/Kros.KORM.UnitTests/Metadata/TableInfoShould.cs
@@ -186,6 +186,19 @@ namespace Kros.KORM.UnitTests.Metadata
             tableInfo.Delimiters.Should().Be(Delimiters.SquareBrackets);
         }
 
+        [Theory]
+        [InlineData("Name", "Name")]
+        [InlineData("[Name]", "Name")]
+        public void GetColumnInfoWithDelimiters(string columnName, string expected)
+        {
+            TableInfo tableInfo = CreateTableInfo();
+
+            tableInfo.UseIdentifierDelimiters(Delimiters.SquareBrackets);
+            ColumnInfo columnInfo = tableInfo.GetColumnInfo(columnName);
+
+            columnInfo.Name.Should().Be(expected);
+        }
+
         private static TableInfo CreateTableInfo()
         {
             var columns = new List<ColumnInfo>();


### PR DESCRIPTION
Fixed issue when used Identifier delimiters like:
```csharp
public override void OnModelCreating(ModelConfigurationBuilder modelBuilder)
{
	modelBuilder.UseIdentifierDelimiters(Delimiters.SquareBrackets);
       ...
}
```

When generating a column list for a command, a column with delimiters was not found in the column list.