### PR TITLE
Fix ORDER BY nullable column in OData query

### DIFF
--- a/src/Database.cs
+++ b/src/Database.cs
@@ -32,6 +32,21 @@ namespace Kros.KORM
         #region Static
 
         /// <summary>
+        /// <para>
+        /// Fixes generating <c>ORDER BY</c> in SQL query based on OData query when the <c>ORDER BY</c> field is nullable.
+        /// </para>
+        /// <para>
+        /// We use <c>ODataQueryOptions&lt;TEntity&gt;.ApplyTo</c> .NET method to apply OData query parameters to KORM query.
+        /// If <c>ORDER BY</c> clause in OData query is using nullable field (column), the condition is generated
+        /// this way: <c>IIF(($item.Field == null), null, $item.Field)</c>. This cannot be used as <c>ORDER BY</c> for SQL query.
+        /// When the value of <c>FixOrderByNullableColumnInODataQuery</c> is <see langword="true"/>, this case is fixed
+        /// when generating SQL. Only <c>$item.Field</c> is used in SQL's <c>ORDER BY</c>.
+        /// Default value is <see langword="false"/>.
+        /// </para>
+        /// </summary>
+        public static bool FixOrderByNullableColumnInODataQuery { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets the default model mapper, which will be used for mapping Object to Relation database.
         /// </summary>
         /// <value>

--- a/src/Database.cs
+++ b/src/Database.cs
@@ -32,21 +32,6 @@ namespace Kros.KORM
         #region Static
 
         /// <summary>
-        /// <para>
-        /// Fixes generating <c>ORDER BY</c> in SQL query based on OData query when the <c>ORDER BY</c> field is nullable.
-        /// </para>
-        /// <para>
-        /// We use <c>ODataQueryOptions&lt;TEntity&gt;.ApplyTo</c> .NET method to apply OData query parameters to KORM query.
-        /// If <c>ORDER BY</c> clause in OData query is using nullable field (column), the condition is generated
-        /// this way: <c>IIF(($item.Field == null), null, $item.Field)</c>. This cannot be used as <c>ORDER BY</c> for SQL query.
-        /// When the value of <c>FixOrderByNullableColumnInODataQuery</c> is <see langword="true"/>, this case is fixed
-        /// when generating SQL. Only <c>$item.Field</c> is used in SQL's <c>ORDER BY</c>.
-        /// Default value is <see langword="false"/>.
-        /// </para>
-        /// </summary>
-        public static bool FixOrderByNullableColumnInODataQuery { get; set; } = false;
-
-        /// <summary>
         /// Gets or sets the default model mapper, which will be used for mapping Object to Relation database.
         /// </summary>
         /// <value>

--- a/src/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -669,17 +669,10 @@ namespace Kros.KORM.Query.Sql
         }
 
         /// <summary>
-        /// <para>
         /// Fixes generating <c>ORDER BY</c> in SQL query based on OData query when the <c>ORDER BY</c> field is nullable.
-        /// </para>
-        /// <para>
         /// We use <c>ODataQueryOptions&lt;TEntity&gt;.ApplyTo</c> .NET method to apply OData query parameters to KORM query.
         /// If <c>ORDER BY</c> clause in OData query is using nullable field (column), the condition is generated
         /// this way: <c>IIF(($item.Field == null), null, $item.Field)</c>. This cannot be used as <c>ORDER BY</c> for SQL query.
-        /// When the value of <c>FixOrderByNullableColumnInODataQuery</c> is <see langword="true"/>, this case is fixed
-        /// when generating SQL. Only <c>$item.Field</c> is used in SQL's <c>ORDER BY</c>.
-        /// Default value is <see langword="false"/>.
-        /// </para>
         /// </summary>
         private Expression FixOrderByNullableColumnInODataQuery(LambdaExpression lambda)
         {

--- a/src/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -668,10 +668,22 @@ namespace Kros.KORM.Query.Sql
             return ret;
         }
 
+        /// <summary>
+        /// <para>
+        /// Fixes generating <c>ORDER BY</c> in SQL query based on OData query when the <c>ORDER BY</c> field is nullable.
+        /// </para>
+        /// <para>
+        /// We use <c>ODataQueryOptions&lt;TEntity&gt;.ApplyTo</c> .NET method to apply OData query parameters to KORM query.
+        /// If <c>ORDER BY</c> clause in OData query is using nullable field (column), the condition is generated
+        /// this way: <c>IIF(($item.Field == null), null, $item.Field)</c>. This cannot be used as <c>ORDER BY</c> for SQL query.
+        /// When the value of <c>FixOrderByNullableColumnInODataQuery</c> is <see langword="true"/>, this case is fixed
+        /// when generating SQL. Only <c>$item.Field</c> is used in SQL's <c>ORDER BY</c>.
+        /// Default value is <see langword="false"/>.
+        /// </para>
+        /// </summary>
         private Expression FixOrderByNullableColumnInODataQuery(LambdaExpression lambda)
         {
-            if (Database.FixOrderByNullableColumnInODataQuery
-                && (lambda.Body is ConditionalExpression conditionalExp)
+            if ((lambda.Body is ConditionalExpression conditionalExp)
                 && (conditionalExp.IfFalse.NodeType == ExpressionType.MemberAccess))
             {
                 return conditionalExp.IfFalse;


### PR DESCRIPTION
Fixes #90 

We use [`ODataQueryOptions<TEntity>.ApplyTo`](docs.microsoft.com/en-us/dotnet/api/microsoft.aspnet.odata.query.odataqueryoptions-1.applyto) .NET method to apply OData query parameters to KORM query. If <c>ORDER BY</c> clause in OData query is using nullable field (column), the condition is generated this way: `IIF(($item.Field == null), null, $item.Field)`. This cannot be used as <c>ORDER BY</c> for SQL query. When the value of `FixOrderByNullableColumnInODataQuery` is `true`, this case is fixed when generating SQL. Only `$item.Field` is used in SQL's `ORDER BY`.
