### PR TITLE
Transaction async commit & Rollback

### DIFF
--- a/src/Data/ITransaction.cs
+++ b/src/Data/ITransaction.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Kros.KORM.Data
 {
@@ -14,9 +16,19 @@ namespace Kros.KORM.Data
         void Commit();
 
         /// <summary>
+        /// Async commits all changes made to the database in the current transaction.
+        /// </summary>
+        Task CommitAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Discards all changes made to the database in the current transaction.
         /// </summary>
         void Rollback();
+
+        /// <summary>
+        /// Async discards all changes made to the database in the current transaction.
+        /// </summary>
+        Task RollbackAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// The time in seconds to wait for the <see cref="System.Data.Common.DbCommand.CommandTimeout">command</see> in this transaction to execute.

--- a/src/Kros.KORM.csproj
+++ b/src/Kros.KORM.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net46</TargetFrameworks>
-    <Version>5.1.1</Version>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <Version>6.0.0</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>KORM is fast, easy to use, micro ORM tool (Kros Object Relation Mapper).</Description>

--- a/src/Query/DbSet.cs
+++ b/src/Query/DbSet.cs
@@ -355,14 +355,14 @@ namespace Kros.KORM.Query
             bool ignoreValueGenerators,
             CancellationToken cancellationToken = default)
         {
-            await _provider.ExecuteInTransactionAsync(async () =>
+            await _provider.ExecuteInTransactionAsync(async (token) =>
             {
-                await CommitChangesAddedItemsAsync(_addedItems, useAsync, ignoreValueGenerators, cancellationToken);
-                await CommitChangesEditedItemsAsync(_editedItems, useAsync, ignoreValueGenerators, cancellationToken);
-                await CommitChangesUpsertedItemsAsync(_upsertedItems, useAsync, cancellationToken);
-                await CommitChangesDeletedItemsAsync(_deletedItems, useAsync, cancellationToken);
-                await CommitChangesDeletedItemsByIdAsync(_deletedItemsIds, useAsync, cancellationToken);
-                await CommitChangesDeletedByConditionsAsync(_deleteExpressions, useAsync, cancellationToken);
+                await CommitChangesAddedItemsAsync(_addedItems, useAsync, ignoreValueGenerators, token);
+                await CommitChangesEditedItemsAsync(_editedItems, useAsync, ignoreValueGenerators, token);
+                await CommitChangesUpsertedItemsAsync(_upsertedItems, useAsync, token);
+                await CommitChangesDeletedItemsAsync(_deletedItems, useAsync, token);
+                await CommitChangesDeletedItemsByIdAsync(_deletedItemsIds, useAsync, token);
+                await CommitChangesDeletedByConditionsAsync(_deleteExpressions, useAsync, token);
 
                 Clear();
             }, cancellationToken);

--- a/src/Query/DbSet.cs
+++ b/src/Query/DbSet.cs
@@ -365,7 +365,7 @@ namespace Kros.KORM.Query
                 await CommitChangesDeletedByConditionsAsync(_deleteExpressions, useAsync, cancellationToken);
 
                 Clear();
-            });
+            }, cancellationToken);
         }
 
         /// <summary>

--- a/src/Query/Providers/IQueryProvider.cs
+++ b/src/Query/Providers/IQueryProvider.cs
@@ -68,10 +68,11 @@ namespace Kros.KORM.Query
         /// Asynchronously executes action in transaction.
         /// </summary>
         /// <param name="action">Action which will be executed.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>
         /// A task that represents the asynchronous operation.
         /// </returns>
-        Task ExecuteInTransactionAsync(Func<Task> action);
+        Task ExecuteInTransactionAsync(Func<Task> action, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes the command.

--- a/src/Query/Providers/IQueryProvider.cs
+++ b/src/Query/Providers/IQueryProvider.cs
@@ -72,7 +72,7 @@ namespace Kros.KORM.Query
         /// <returns>
         /// A task that represents the asynchronous operation.
         /// </returns>
-        Task ExecuteInTransactionAsync(Func<Task> action, CancellationToken cancellationToken = default);
+        Task ExecuteInTransactionAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes the command.

--- a/src/Query/Providers/QueryProvider.cs
+++ b/src/Query/Providers/QueryProvider.cs
@@ -278,14 +278,14 @@ namespace Kros.KORM.Query
         }
 
         /// <inheritdoc/>
-        public async Task ExecuteInTransactionAsync(Func<Task> action, CancellationToken cancellationToken = default)
+        public async Task ExecuteInTransactionAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken = default)
         {
             using (OpenConnection())
             using (var transaction = _transactionHelper.Value.BeginTransaction())
             {
                 try
                 {
-                    await action();
+                    await action(cancellationToken);
                     await transaction.CommitAsync(cancellationToken);
                 }
                 catch

--- a/src/Query/Providers/QueryProvider.cs
+++ b/src/Query/Providers/QueryProvider.cs
@@ -286,11 +286,11 @@ namespace Kros.KORM.Query
                 try
                 {
                     await action();
-                    transaction.Commit();
+                    await transaction.CommitAsync();
                 }
                 catch
                 {
-                    transaction.Rollback();
+                    await transaction.RollbackAsync();
                     throw;
                 }
             }

--- a/src/Query/Providers/QueryProvider.cs
+++ b/src/Query/Providers/QueryProvider.cs
@@ -278,7 +278,7 @@ namespace Kros.KORM.Query
         }
 
         /// <inheritdoc/>
-        public async Task ExecuteInTransactionAsync(Func<Task> action)
+        public async Task ExecuteInTransactionAsync(Func<Task> action, CancellationToken cancellationToken = default)
         {
             using (OpenConnection())
             using (var transaction = _transactionHelper.Value.BeginTransaction())
@@ -286,11 +286,11 @@ namespace Kros.KORM.Query
                 try
                 {
                     await action();
-                    await transaction.CommitAsync();
+                    await transaction.CommitAsync(cancellationToken);
                 }
                 catch
                 {
-                    await transaction.RollbackAsync();
+                    await transaction.RollbackAsync(cancellationToken);
                     throw;
                 }
             }

--- a/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
@@ -324,7 +324,7 @@ namespace Kros.KORM.UnitTests
 
         private class FakeProvider : IQueryProvider
         {
-            async Task IQueryProvider.ExecuteInTransactionAsync(Func<Task> action) => await action();
+            async Task IQueryProvider.ExecuteInTransactionAsync(Func<Task> action, CancellationToken cancellationToken) => await action();
             int IQueryProvider.ExecuteNonQueryCommand(IDbCommand command) => command.ExecuteNonQuery();
             bool IQueryProvider.SupportsIdentity() => false;
             bool IQueryProvider.SupportsPrepareCommand() => true;

--- a/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/DbSetShould.cs
@@ -324,7 +324,7 @@ namespace Kros.KORM.UnitTests
 
         private class FakeProvider : IQueryProvider
         {
-            async Task IQueryProvider.ExecuteInTransactionAsync(Func<Task> action, CancellationToken cancellationToken) => await action();
+            async Task IQueryProvider.ExecuteInTransactionAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken) => await action(cancellationToken);
             int IQueryProvider.ExecuteNonQueryCommand(IDbCommand command) => command.ExecuteNonQuery();
             bool IQueryProvider.SupportsIdentity() => false;
             bool IQueryProvider.SupportsPrepareCommand() => true;


### PR DESCRIPTION
Closes #102.

Implementation of `async` versions of the `Commit` and `Rollback` methods for the transaction.

## ⚠️ Breaking change

Remove targeting for the old .NET 4.6 framework _(`DbTransaction` does not contain `async` variants in this framework)_