### PR TITLE
Upgrade to .NET 8

### DIFF
--- a/src/CommandGenerator/CommandGenerator.cs
+++ b/src/CommandGenerator/CommandGenerator.cs
@@ -249,7 +249,7 @@ SELECT * FROM @OutputTable;";
             }
         }
 
-        private void AddDeleteCommandParameter(DbCommand cmd, string parameterName, object value)
+        private static void AddDeleteCommandParameter(DbCommand cmd, string parameterName, object value)
         {
             DbParameter newParameter = cmd.CreateParameter();
             newParameter.ParameterName = parameterName;
@@ -257,7 +257,7 @@ SELECT * FROM @OutputTable;";
             cmd.Parameters.Add(newParameter);
         }
 
-        private DbCommand FinishDeleteCommand(DbCommand cmd, StringBuilder deleteQueryText)
+        private static DbCommand FinishDeleteCommand(DbCommand cmd, StringBuilder deleteQueryText)
         {
             deleteQueryText.Append(")");
             cmd.CommandText = deleteQueryText.ToString();
@@ -317,7 +317,7 @@ SELECT * FROM @OutputTable;";
             return value;
         }
 
-        internal void SetColumnValueFromValueGenerator(ColumnInfo columnInfo, T item, ValueGenerated valueGenerated)
+        internal static void SetColumnValueFromValueGenerator(ColumnInfo columnInfo, T item, ValueGenerated valueGenerated)
         {
             if ((!HasValueGeneratorOnInsert(columnInfo) || valueGenerated != ValueGenerated.OnUpdate) &&
                 TryGetValueFromValueGenerators(columnInfo, valueGenerated, out object generatorValue))
@@ -326,10 +326,10 @@ SELECT * FROM @OutputTable;";
             }
         }
 
-        private bool HasValueGeneratorOnInsert(ColumnInfo columnInfo)
+        private static bool HasValueGeneratorOnInsert(ColumnInfo columnInfo)
             => (columnInfo.ValueGenerator != null && columnInfo.ValueGenerated == ValueGenerated.OnInsert);
 
-        private bool TryGetValueFromValueGenerators(ColumnInfo columnInfo, ValueGenerated valueGenerated, out object value)
+        private static bool TryGetValueFromValueGenerators(ColumnInfo columnInfo, ValueGenerated valueGenerated, out object value)
         {
             value = null;
 

--- a/src/CommandGenerator/CommandGenerator.cs
+++ b/src/CommandGenerator/CommandGenerator.cs
@@ -200,7 +200,7 @@ SELECT * FROM @OutputTable;";
                 AddDeleteCommandParameter(cmd, paramterName, id);
                 if (iterationCount > 1)
                 {
-                    deleteQueryText.Append(",");
+                    deleteQueryText.Append(',');
                 }
                 deleteQueryText.Append(paramterName);
 
@@ -259,7 +259,7 @@ SELECT * FROM @OutputTable;";
 
         private static DbCommand FinishDeleteCommand(DbCommand cmd, StringBuilder deleteQueryText)
         {
-            deleteQueryText.Append(")");
+            deleteQueryText.Append(')');
             cmd.CommandText = deleteQueryText.ToString();
             return cmd;
         }

--- a/src/CommandGenerator/CommandGenerator.cs
+++ b/src/CommandGenerator/CommandGenerator.cs
@@ -272,7 +272,7 @@ SELECT * FROM @OutputTable;";
         public IEnumerable<ColumnInfo> GetQueryColumns(ValueGenerated valueGenerated)
             => GetQueryColumns().Where(c => c.ValueGenerator == null || c.ValueGenerated.HasFlag(valueGenerated));
 
-        private IEnumerable<ColumnInfo> GetQueryColumns()
+        private List<ColumnInfo> GetQueryColumns()
         {
             if (_columnsInfo == null)
             {

--- a/src/Data/DataRowReader.cs
+++ b/src/Data/DataRowReader.cs
@@ -72,7 +72,7 @@ namespace Kros.KORM.Data
                     }
                     catch (IndexOutOfRangeException)
                     {
-                        throw new ArgumentOutOfRangeException("ordinal");
+                        throw new ArgumentOutOfRangeException(nameof(ordinal));
                     }
                 }
                 throw new InvalidOperationException("Cannot process deleted row.");
@@ -180,7 +180,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -200,7 +200,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -226,7 +226,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
             if (buffer == null)
                 return (long)numArray.Length;
@@ -234,11 +234,11 @@ namespace Kros.KORM.Data
             int num2 = Math.Min(numArray.Length - num1, length);
             if (num1 < 0)
             {
-                throw new ArgumentOutOfRangeException("dataOffset");
+                throw new ArgumentOutOfRangeException(nameof(dataOffset));
             }
             if (bufferOffset < 0 || bufferOffset > 0 && bufferOffset >= buffer.Length)
             {
-                throw new ArgumentOutOfRangeException("bufferOffset");
+                throw new ArgumentOutOfRangeException(nameof(bufferOffset));
             }
             if (0 < num2)
             {
@@ -248,7 +248,7 @@ namespace Kros.KORM.Data
             {
                 if (length < 0)
                 {
-                    throw new ArgumentOutOfRangeException("length");
+                    throw new ArgumentOutOfRangeException(nameof(length));
                 }
                 num2 = 0;
             }
@@ -271,7 +271,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -296,7 +296,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
             if (buffer == null)
                 return (long)chArray.Length;
@@ -304,11 +304,11 @@ namespace Kros.KORM.Data
             int num2 = Math.Min(chArray.Length - num1, length);
             if (num1 < 0)
             {
-                throw new ArgumentOutOfRangeException("dataOffset");
+                throw new ArgumentOutOfRangeException(nameof(dataOffset));
             }
             if (bufferOffset < 0 || bufferOffset > 0 && bufferOffset >= buffer.Length)
             {
-                throw new ArgumentOutOfRangeException("bufferOffset");
+                throw new ArgumentOutOfRangeException(nameof(bufferOffset));
             }
             if (0 < num2)
             {
@@ -318,7 +318,7 @@ namespace Kros.KORM.Data
             {
                 if (length < 0)
                 {
-                    throw new ArgumentOutOfRangeException("length");
+                    throw new ArgumentOutOfRangeException(nameof(length));
                 }
                 num2 = 0;
             }
@@ -354,7 +354,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -374,7 +374,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -394,7 +394,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -426,7 +426,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -446,7 +446,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -466,7 +466,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -486,7 +486,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -506,7 +506,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -526,7 +526,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -546,7 +546,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -598,7 +598,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -618,7 +618,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -634,7 +634,7 @@ namespace Kros.KORM.Data
         {
             if (values == null)
             {
-                throw new ArgumentNullException("values");
+                throw new ArgumentNullException(nameof(values));
             }
             Array.Copy((Array)_dataRow.ItemArray,
                 (Array)values, _dataRow.ItemArray.Length > values.Length ? values.Length : _dataRow.ItemArray.Length);
@@ -662,7 +662,7 @@ namespace Kros.KORM.Data
             }
             catch (IndexOutOfRangeException)
             {
-                throw new ArgumentOutOfRangeException("ordinal");
+                throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
         }
 
@@ -693,7 +693,7 @@ namespace Kros.KORM.Data
         {
             if (table == null)
             {
-                throw new ArgumentNullException("DataTable");
+                throw new ArgumentNullException(nameof(table));
             }
             return new DataTableReader(table).GetSchemaTable();
         }

--- a/src/Data/DataRowReader.cs
+++ b/src/Data/DataRowReader.cs
@@ -229,7 +229,9 @@ namespace Kros.KORM.Data
                 throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
             if (buffer == null)
+            {
                 return (long)numArray.Length;
+            }
             int num1 = (int)dataOffset;
             int num2 = Math.Min(numArray.Length - num1, length);
             if (num1 < 0)
@@ -299,7 +301,9 @@ namespace Kros.KORM.Data
                 throw new ArgumentOutOfRangeException(nameof(ordinal));
             }
             if (buffer == null)
+            {
                 return (long)chArray.Length;
+            }
             int num1 = (int)dataOffset;
             int num2 = Math.Min(chArray.Length - num1, length);
             if (num1 < 0)

--- a/src/Data/DataRowReader.cs
+++ b/src/Data/DataRowReader.cs
@@ -14,8 +14,8 @@ namespace Kros.KORM.Data
     [ExcludeFromCodeCoverage()]
     internal class DataRowReader : DbDataReader
     {
-        private DataTable _dataTable;
-        private DataRow _dataRow;
+        private readonly DataTable _dataTable;
+        private readonly DataRow _dataRow;
         private bool _isOpen = true;
         private bool _reachEORows = false;
         private DataTable _schemaTable;

--- a/src/Data/DataRowReader.cs
+++ b/src/Data/DataRowReader.cs
@@ -18,7 +18,7 @@ namespace Kros.KORM.Data
         private DataRow _dataRow;
         private bool _isOpen = true;
         private bool _reachEORows = false;
-        private DataTable schemaTable;
+        private DataTable _schemaTable;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DataRowReader"/> class.
@@ -575,11 +575,11 @@ namespace Kros.KORM.Data
         /// </exception>
         public override DataTable GetSchemaTable()
         {
-            if (this.schemaTable == null)
+            if (_schemaTable == null)
             {
-                this.schemaTable = DataRowReader.GetSchemaTableFromDataTable(_dataTable);
+                _schemaTable = DataRowReader.GetSchemaTableFromDataTable(_dataTable);
             }
-            return this.schemaTable;
+            return _schemaTable;
         }
 
         /// <summary>

--- a/src/Kros.KORM.csproj
+++ b/src/Kros.KORM.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Version>6.2.0</Version>
+    <Version>7.0.0</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>KORM is fast, easy to use, micro ORM tool (Kros Object Relation Mapper).</Description>

--- a/src/Kros.KORM.csproj
+++ b/src/Kros.KORM.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Version>6.2.0</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
@@ -47,8 +47,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kros.Utils" Version="2.1.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Kros.Utils" Version="3.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/src/Materializer/DynamicMethodModelFactory.cs
+++ b/src/Materializer/DynamicMethodModelFactory.cs
@@ -96,12 +96,12 @@ namespace Kros.KORM.Materializer
             DynamicMethod dynamicMethod = new(GetFactoryName, type, new Type[] { typeof(IDataReader) }, true);
             ILGenerator ilGenerator = dynamicMethod.GetILGenerator();
 
-            ilGenerator.DeclareLocal(typeof(T));
+            LocalBuilder localResult = ilGenerator.DeclareLocal(typeof(T));
             ilGenerator.LogAndEmit(OpCodes.Newobj, ctor);
-            ilGenerator.LogAndEmit(OpCodes.Stloc_0);
+            ilGenerator.LogAndEmit(OpCodes.Stloc_S, localResult.LocalIndex);
             EmitReaderFields(reader, tableInfo, ilGenerator, injector);
             ilGenerator.CallOnAfterMaterialize(tableInfo);
-            ilGenerator.LogAndEmit(OpCodes.Ldloc_0);
+            ilGenerator.LogAndEmit(OpCodes.Ldloc, localResult.LocalIndex);
             ilGenerator.LogAndEmit(OpCodes.Ret);
 
             return dynamicMethod.CreateDelegate(Expression.GetFuncType(typeof(IDataReader), type)) as Func<IDataReader, T>;

--- a/src/Materializer/ILGeneratorHelper.cs
+++ b/src/Materializer/ILGeneratorHelper.cs
@@ -1,4 +1,4 @@
-﻿using Kros.Extensions;
+using Kros.Extensions;
 using Kros.KORM.Converter;
 using Kros.KORM.Injection;
 using Kros.KORM.Metadata;
@@ -337,12 +337,26 @@ namespace Kros.KORM.Materializer
             }
         }
 
+        private static readonly FieldInfo _zeroDecimal = typeof(decimal).GetField(nameof(decimal.Zero));
+
         private static void EmitSetDefaultValueForValueTypes(this ILGenerator ilGenerator, Type propertyType)
         {
-            LocalBuilder local = ilGenerator.DeclareLocal(propertyType);
-            ilGenerator.LogAndEmit(OpCodes.Ldloca_S, local.LocalIndex);
-            ilGenerator.LogAndEmit(OpCodes.Initobj, local.LocalType);
-            ilGenerator.LogAndEmit(OpCodes.Ldloc_S, local.LocalIndex);
+            if (propertyType == typeof(decimal))
+            {
+                ilGenerator.LogAndEmit(OpCodes.Ldsfld, _zeroDecimal);
+            }
+            else if (propertyType.IsEnum)
+            {
+                ilGenerator.EmitSetDefaultValueForPrimitiveTypes(propertyType.GetEnumUnderlyingType());
+            }
+            else
+            {
+                // TODO: Try some structs?
+                LocalBuilder local = ilGenerator.DeclareLocal(propertyType);
+                ilGenerator.LogAndEmit(OpCodes.Ldloca_S, local.LocalIndex);
+                ilGenerator.LogAndEmit(OpCodes.Initobj, local.LocalType);
+                ilGenerator.LogAndEmit(OpCodes.Ldloc, local.LocalIndex);
+            }
         }
 
         private static Dictionary<string, MethodInfo> InitReaderValueGetters()

--- a/src/Materializer/ILGeneratorHelper.cs
+++ b/src/Materializer/ILGeneratorHelper.cs
@@ -1,4 +1,4 @@
-using Kros.Extensions;
+﻿using Kros.Extensions;
 using Kros.KORM.Converter;
 using Kros.KORM.Injection;
 using Kros.KORM.Metadata;
@@ -351,7 +351,6 @@ namespace Kros.KORM.Materializer
             }
             else
             {
-                // TODO: Try some structs?
                 LocalBuilder local = ilGenerator.DeclareLocal(propertyType);
                 ilGenerator.LogAndEmit(OpCodes.Ldloca_S, local.LocalIndex);
                 ilGenerator.LogAndEmit(OpCodes.Initobj, local.LocalType);

--- a/src/Materializer/ModelBuilder.cs
+++ b/src/Materializer/ModelBuilder.cs
@@ -196,7 +196,7 @@ namespace Kros.KORM.Materializer
 
             private Func<IDataReader, T> _modelFactory;
             private IDataReader _reader;
-            private T _currentItem = default(T);
+            private T _currentItem = default;
 
             #endregion
 
@@ -234,7 +234,7 @@ namespace Kros.KORM.Materializer
             public bool MoveNext()
             {
                 var result = _reader.Read();
-                _currentItem = result ? _modelFactory(_reader) : default(T);
+                _currentItem = result ? _modelFactory(_reader) : default;
                 return result;
             }
 
@@ -249,7 +249,7 @@ namespace Kros.KORM.Materializer
                 }
                 _modelFactory = null;
                 _reader = null;
-                _currentItem = default(T);
+                _currentItem = default;
             }
 
             /// <summary>

--- a/src/Materializer/ModelBuilder.cs
+++ b/src/Materializer/ModelBuilder.cs
@@ -320,7 +320,7 @@ namespace Kros.KORM.Materializer
         /// </returns>
         public IEnumerable<T> Materialize<T>(DataTable table)
         {
-            return this.Materialize<T>(new DataTableReader(table));
+            return Materialize<T>(new DataTableReader(table));
         }
 
         /// <summary>
@@ -333,7 +333,7 @@ namespace Kros.KORM.Materializer
         /// </returns>
         public T Materialize<T>(DataRow dataRow)
         {
-            return this.Materialize<T>(new DataRowReader(dataRow)).FirstOrDefault();
+            return Materialize<T>(new DataRowReader(dataRow)).FirstOrDefault();
         }
     }
 }

--- a/src/Materializer/ModelBuilder.cs
+++ b/src/Materializer/ModelBuilder.cs
@@ -22,9 +22,9 @@ namespace Kros.KORM.Materializer
         {
             #region Fields
 
-            IDbCommand _command;
-            IDataReader _reader;
-            bool _closeConnectionWhenFinished;
+            private IDbCommand _command;
+            private IDataReader _reader;
+            private readonly bool _closeConnectionWhenFinished;
 
             #endregion
 
@@ -268,7 +268,7 @@ namespace Kros.KORM.Materializer
 
         #region Private Fields
 
-        private IModelFactory _modelFactory;
+        private readonly IModelFactory _modelFactory;
 
         #endregion
 

--- a/src/Materializer/RecordModelFactory.cs
+++ b/src/Materializer/RecordModelFactory.cs
@@ -46,11 +46,11 @@ namespace Kros.KORM.Materializer
                 }
             }
 
-            ilGenerator.DeclareLocal(typeof(T));
+            LocalBuilder localResult = ilGenerator.DeclareLocal(typeof(T));
             ilGenerator.LogAndEmit(OpCodes.Newobj, ctor);
-            ilGenerator.LogAndEmit(OpCodes.Stloc_0);
+            ilGenerator.LogAndEmit(OpCodes.Stloc_S, localResult.LocalIndex);
             ilGenerator.CallOnAfterMaterialize(tableInfo);
-            ilGenerator.LogAndEmit(OpCodes.Ldloc_0);
+            ilGenerator.LogAndEmit(OpCodes.Ldloc, localResult.LocalIndex);
             ilGenerator.LogAndEmit(OpCodes.Ret);
 
             return dynamicMethod.CreateDelegate(Expression.GetFuncType(typeof(IDataReader), type)) as Func<IDataReader, T>;

--- a/src/Metadata/ConventionModelMapper.cs
+++ b/src/Metadata/ConventionModelMapper.cs
@@ -294,7 +294,7 @@ namespace Kros.KORM.Metadata
             return string.IsNullOrWhiteSpace(name) ? MapColumnName(columnInfo, modelType) : name;
         }
 
-        private IConverter GetConverterFromAttribute(PropertyInfo propertyInfo)
+        private static IConverter GetConverterFromAttribute(PropertyInfo propertyInfo)
         {
             var attributes = propertyInfo.GetCustomAttributes(typeof(ConverterAttribute), true);
             if (attributes.Length == 1)
@@ -307,7 +307,7 @@ namespace Kros.KORM.Metadata
             }
         }
 
-        private string GetName(ICustomAttributeProvider attributeProvider)
+        private static string GetName(ICustomAttributeProvider attributeProvider)
         {
             var aliasAttr = attributeProvider.GetCustomAttributes(typeof(AliasAttribute), true)
                 .FirstOrDefault() as AliasAttribute;

--- a/src/Metadata/ConventionModelMapper.cs
+++ b/src/Metadata/ConventionModelMapper.cs
@@ -315,7 +315,7 @@ namespace Kros.KORM.Metadata
             return aliasAttr?.Alias;
         }
 
-        private static IEnumerable<ColumnInfo> OnMapPrimaryKey(TableInfo tableInfo)
+        private static List<ColumnInfo> OnMapPrimaryKey(TableInfo tableInfo)
         {
             ColumnInfo pkByConvention = null;
             var pkByAttributes = new List<(ColumnInfo Column, KeyAttribute Attribute)>();

--- a/src/Query/DbSet.cs
+++ b/src/Query/DbSet.cs
@@ -26,17 +26,17 @@ namespace Kros.KORM.Query
     {
         #region Private fields
 
-        private ICommandGenerator<T> _commandGenerator;
-        private IQueryProvider _provider;
-        private IQueryBase<T> _query;
-        private HashSet<T> _addedItems = new HashSet<T>();
-        private HashSet<T> _editedItems = new HashSet<T>();
-        private HashSet<T> _deletedItems = new HashSet<T>();
-        private HashSet<T> _upsertedItems = new HashSet<T>();
-        private HashSet<object> _deletedItemsIds = new HashSet<object>();
-        private List<WhereExpression> _deleteExpressions = new List<WhereExpression>();
+        private readonly ICommandGenerator<T> _commandGenerator;
+        private readonly IQueryProvider _provider;
+        private readonly IQueryBase<T> _query;
+        private readonly HashSet<T> _addedItems = new HashSet<T>();
+        private readonly HashSet<T> _editedItems = new HashSet<T>();
+        private readonly HashSet<T> _deletedItems = new HashSet<T>();
+        private readonly HashSet<T> _upsertedItems = new HashSet<T>();
+        private readonly HashSet<object> _deletedItemsIds = new HashSet<object>();
+        private readonly List<WhereExpression> _deleteExpressions = new List<WhereExpression>();
         private readonly TableInfo _tableInfo;
-        private Lazy<Type> _primaryKeyPropertyType;
+        private readonly Lazy<Type> _primaryKeyPropertyType;
         private IEnumerable<string> _upsertConditionColumnNames;
 
         #endregion

--- a/src/Query/DbSet.cs
+++ b/src/Query/DbSet.cs
@@ -610,7 +610,7 @@ namespace Kros.KORM.Query
             }
         }
 
-        private void CheckItemInCollection(T entity, HashSet<T> collection, string message, string collectionName)
+        private static void CheckItemInCollection(T entity, HashSet<T> collection, string message, string collectionName)
         {
             if (collection.Contains(entity))
             {

--- a/src/Query/DbSet.cs
+++ b/src/Query/DbSet.cs
@@ -402,7 +402,7 @@ namespace Kros.KORM.Query
 
         #region Private Helpers
 
-        private void PrepareCommand(IDbCommand command)
+        private void PrepareCommand(DbCommand command)
         {
             if (_provider.SupportsPrepareCommand())
             {

--- a/src/Query/Expressions/PartialEvaluator.cs
+++ b/src/Query/Expressions/PartialEvaluator.cs
@@ -111,7 +111,7 @@ namespace Kros.KORM.Query.Expressions
             {
                 if (expression != null)
                 {
-                    bool saveCannotBeEvaluated = this._cannotBeEvaluated;
+                    bool saveCannotBeEvaluated = _cannotBeEvaluated;
                     _cannotBeEvaluated = false;
                     base.Visit(expression);
                     if (!_cannotBeEvaluated)

--- a/src/Query/Expressions/PartialEvaluator.cs
+++ b/src/Query/Expressions/PartialEvaluator.cs
@@ -42,7 +42,7 @@ namespace Kros.KORM.Query.Expressions
         /// </summary>
         class SubtreeEvaluator : ExpressionVisitor
         {
-            private HashSet<Expression> _candidates;
+            private readonly HashSet<Expression> _candidates;
 
             private SubtreeEvaluator(HashSet<Expression> candidates)
             {
@@ -90,8 +90,8 @@ namespace Kros.KORM.Query.Expressions
         /// </summary>
         class Nominator : ExpressionVisitor
         {
-            private Func<Expression, bool> _canBeEvaluated;
-            private HashSet<Expression> _candidates;
+            private readonly Func<Expression, bool> _canBeEvaluated;
+            private readonly HashSet<Expression> _candidates;
             private bool _cannotBeEvaluated;
 
             private Nominator(Func<Expression, bool> fnCanBeEvaluated)

--- a/src/Query/Expressions/PartialEvaluator.cs
+++ b/src/Query/Expressions/PartialEvaluator.cs
@@ -67,7 +67,7 @@ namespace Kros.KORM.Query.Expressions
                 return base.Visit(exp);
             }
 
-            private Expression Evaluate(Expression e)
+            private static Expression Evaluate(Expression e)
             {
                 if (e.NodeType == ExpressionType.Constant)
                 {

--- a/src/Query/Query.cs
+++ b/src/Query/Query.cs
@@ -22,8 +22,8 @@ namespace Kros.KORM.Query
 
         #region Private fields
 
-        private IDatabaseMapper _databaseMapper;
-        private IQueryProvider _provider;
+        private readonly IDatabaseMapper _databaseMapper;
+        private readonly IQueryProvider _provider;
         private bool _ignoreQueryFilters = false;
 
         #endregion

--- a/src/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -864,7 +864,7 @@ namespace Kros.KORM.Query.Sql
         /// Visits the constant.
         /// </summary>
         /// <param name="expression">The expression.</param>
-        /// <exception cref="System.NotSupportedException">If type of constant is <see cref="System.Object"/>.</exception>
+        /// <exception cref="NotSupportedException">If type of constant is <see cref="object"/>.</exception>
         protected override Expression VisitConstant(ConstantExpression expression)
         {
             if (expression.Value == null)

--- a/src/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -361,16 +361,22 @@ namespace Kros.KORM.Query.Sql
             if (expression is ConstantExpression cex)
             {
                 if (cex.Value is IQueryable query && query.Provider == this)
+                {
                     return false;
+                }
             }
             if (expression is MethodCallExpression mc &&
                 (mc.Method.DeclaringType == typeof(Enumerable) ||
                  mc.Method.DeclaringType == typeof(Queryable)))
+            {
                 return false;
+            }
 
             if (expression.NodeType == ExpressionType.Convert &&
                 expression.Type == typeof(object))
+            {
                 return true;
+            }
 
             return expression.NodeType != ExpressionType.Parameter &&
                    expression.NodeType != ExpressionType.Lambda;

--- a/src/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -147,7 +147,7 @@ namespace Kros.KORM.Query.Sql
         {
             if (Orders.Count > 0)
             {
-                SqlBuilder.Append(" ");
+                SqlBuilder.Append(' ');
                 SqlBuilder.Append(CreateOrderByString());
             }
         }
@@ -211,7 +211,7 @@ namespace Kros.KORM.Query.Sql
         public virtual Expression VisitSelect(SelectExpression selectExpression)
         {
             SqlBuilder.Append(SelectExpression.SelectStatement);
-            SqlBuilder.Append(" ");
+            SqlBuilder.Append(' ');
 
             if (_top > 0)
             {
@@ -620,7 +620,7 @@ namespace Kros.KORM.Query.Sql
         {
             LinqStringBuilder.Append($"{aggregateName.ToUpper()}(");
             Visit(StripQuotes(expression.Arguments[1]));
-            LinqStringBuilder.Append(")");
+            LinqStringBuilder.Append(')');
 
             SelectExpression.SetColumnsExpression(new ColumnsExpression(LinqStringBuilder.ToString()));
             LinqStringBuilder.Clear();
@@ -762,11 +762,11 @@ namespace Kros.KORM.Query.Sql
         protected override Expression VisitBinary(BinaryExpression expression)
         {
             bool hasBooleanOperator = HasBooleanOperator(expression);
-            LinqStringBuilder.Append("(");
+            LinqStringBuilder.Append('(');
             ProcessBinaryExpressionOperand(expression.Left, hasBooleanOperator);
             AppendOperator(expression);
             ProcessBinaryExpressionOperand(expression.Right, hasBooleanOperator);
-            LinqStringBuilder.Append(")");
+            LinqStringBuilder.Append(')');
             return expression;
         }
 
@@ -1002,7 +1002,7 @@ namespace Kros.KORM.Query.Sql
             {
                 AddParameterWithValue(substringMaxLength);
             }
-            LinqStringBuilder.Append(")");
+            LinqStringBuilder.Append(')');
             return expression;
         }
 
@@ -1018,7 +1018,7 @@ namespace Kros.KORM.Query.Sql
             Visit(expression.Arguments[0]);
             LinqStringBuilder.Append(", ");
             Visit(expression.Arguments[1]);
-            LinqStringBuilder.Append(")");
+            LinqStringBuilder.Append(')');
             return expression;
         }
 
@@ -1030,7 +1030,7 @@ namespace Kros.KORM.Query.Sql
         {
             LinqStringBuilder.Append("LOWER(");
             Visit(expression.Object);
-            LinqStringBuilder.Append(")");
+            LinqStringBuilder.Append(')');
             return expression;
         }
 
@@ -1042,7 +1042,7 @@ namespace Kros.KORM.Query.Sql
         {
             LinqStringBuilder.Append("UPPER(");
             Visit(expression.Object);
-            LinqStringBuilder.Append(")");
+            LinqStringBuilder.Append(')');
             return expression;
         }
 
@@ -1052,7 +1052,7 @@ namespace Kros.KORM.Query.Sql
         /// <param name="expression">The expression.</param>
         protected virtual Expression BindIsNullOrEmpty(MethodCallExpression expression)
         {
-            LinqStringBuilder.Append("(");
+            LinqStringBuilder.Append('(');
             Visit(expression.Arguments[0]);
             LinqStringBuilder.Append(" IS NULL OR ");
             Visit(expression.Arguments[0]);
@@ -1066,7 +1066,7 @@ namespace Kros.KORM.Query.Sql
         /// <param name="expression">The expression.</param>
         protected virtual Expression BindContains(MethodCallExpression expression)
         {
-            LinqStringBuilder.Append("(");
+            LinqStringBuilder.Append('(');
             Visit(expression.Object);
             LinqStringBuilder.Append(" LIKE '%' + ");
             Visit(expression.Arguments[0]);
@@ -1080,11 +1080,11 @@ namespace Kros.KORM.Query.Sql
         /// <param name="expression">The expression.</param>
         protected virtual Expression BindEndWith(MethodCallExpression expression)
         {
-            LinqStringBuilder.Append("(");
+            LinqStringBuilder.Append('(');
             Visit(expression.Object);
             LinqStringBuilder.Append(" LIKE '%' + ");
             Visit(expression.Arguments[0]);
-            LinqStringBuilder.Append(")");
+            LinqStringBuilder.Append(')');
             return expression;
         }
 
@@ -1094,7 +1094,7 @@ namespace Kros.KORM.Query.Sql
         /// <param name="expression">The expression.</param>
         protected virtual Expression BindStartWith(MethodCallExpression expression)
         {
-            LinqStringBuilder.Append("(");
+            LinqStringBuilder.Append('(');
             Visit(expression.Object);
             LinqStringBuilder.Append(" LIKE ");
             Visit(expression.Arguments[0]);

--- a/src/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -347,7 +347,7 @@ namespace Kros.KORM.Query.Sql
             LinqStringBuilder.AppendFormat("({0} {1} {2})", GetColumnNameFromMember(node), op, value ? SqlTrue : SqlFalse);
         }
 
-        private bool IsBooleanPropertyExpression(Expression node)
+        private static bool IsBooleanPropertyExpression(Expression node)
         {
             if ((node is MemberExpression memberExp) && (memberExp.Member is PropertyInfo propInfo))
             {
@@ -684,10 +684,10 @@ namespace Kros.KORM.Query.Sql
             return ret;
         }
 
-        private Expression VisitSelect(MethodCallExpression expression)
+        private static Expression VisitSelect(MethodCallExpression expression)
             => ThrowNotSupportedException(expression);
 
-        private Expression VisitGroupBy(MethodCallExpression expression)
+        private static Expression VisitGroupBy(MethodCallExpression expression)
             => ThrowNotSupportedException(expression);
 
         /// <summary>
@@ -854,7 +854,7 @@ namespace Kros.KORM.Query.Sql
             }
         }
 
-        private bool HasBooleanOperator(BinaryExpression node)
+        private static bool HasBooleanOperator(BinaryExpression node)
             => (node.NodeType == ExpressionType.And)
                 || (node.NodeType == ExpressionType.AndAlso)
                 || (node.NodeType == ExpressionType.Or)

--- a/src/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -1132,7 +1132,7 @@ namespace Kros.KORM.Query.Sql
         protected class Parameters
         {
             private int _parametersCount = 0;
-            private List<object> _params = new List<object>();
+            private readonly List<object> _params = new List<object>();
             private readonly string _parameterNamePrefix;
 
             /// <summary>

--- a/src/Query/Sql/ParameterExtractingExpressionVisitor.cs
+++ b/src/Query/Sql/ParameterExtractingExpressionVisitor.cs
@@ -13,7 +13,7 @@ namespace Kros.KORM.Query.Sql
     /// <seealso cref="System.Linq.Expressions.ExpressionVisitor" />
     public class ParameterExtractingExpressionVisitor : ExpressionVisitor
     {
-        private DbCommand _command;
+        private readonly DbCommand _command;
 
         private ParameterExtractingExpressionVisitor(DbCommand command)
         {

--- a/tests/Kros.KORM.PerformanceTests/Kros.KORM.PerformanceTests.csproj
+++ b/tests/Kros.KORM.PerformanceTests/Kros.KORM.PerformanceTests.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
     <PackageReference Include="MMLib.RapidPrototyping" Version="1.3.0" />
   </ItemGroup>
 

--- a/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
+++ b/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
@@ -359,10 +359,10 @@ SELECT * FROM @OutputTable;";
             return new CommandGenerator<Foo>(GetFooTableInfo(), provider, query);
         }
 
-        private static IQuery<Foo> CreateFooQuery()
+        private static Query<Foo> CreateFooQuery()
             => CreateQuery<Foo>();
 
-        private static IQuery<T> CreateQuery<T>()
+        private static Query<T> CreateQuery<T>()
         {
             var query = new Query<T>(
                 new DatabaseMapper(new ConventionModelMapper()),
@@ -431,7 +431,7 @@ SELECT * FROM @OutputTable;";
             return new CommandGenerator<FooIdentity>(GetFooIdentityTableInfo(), provider, query);
         }
 
-        private static IQuery<FooIdentity> CreateFooIdentityQuery()
+        private static Query<FooIdentity> CreateFooIdentityQuery()
         {
             var query = new Query<FooIdentity>(
                 new DatabaseMapper(new ConventionModelMapper()),

--- a/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
+++ b/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
@@ -265,7 +265,7 @@ SELECT * FROM @OutputTable;";
             CommandGenerator<ConverterDto> commandGenerator = CreateCommandGenerator<ConverterDto>(tableInfo);
 
             var dto = new ConverterDto() { Id = 1, Name = null };
-            commandGenerator.SetColumnValueFromValueGenerator(idColumn, dto, ValueGenerated.Never);
+            CommandGenerator<ConverterDto>.SetColumnValueFromValueGenerator(idColumn, dto, ValueGenerated.Never);
             var convertedValue = commandGenerator.GetColumnValue(idColumn, dto, ValueGenerated.Never);
 
             convertedValue.Should().Be(AutoIncrementValueGenerator.GeneratedValue);
@@ -327,7 +327,7 @@ SELECT * FROM @OutputTable;";
 
         #region Test Classes and Methods
 
-        private List<T> GetParameterValues<T>(DbParameterCollection parameters)
+        private static List<T> GetParameterValues<T>(DbParameterCollection parameters)
         {
             var result = new List<T>();
 
@@ -339,7 +339,7 @@ SELECT * FROM @OutputTable;";
             return result;
         }
 
-        private CommandGenerator<Foo> GetFooGenerator()
+        private static CommandGenerator<Foo> GetFooGenerator()
         {
             KORM.Query.IQueryProvider provider = Substitute.For<KORM.Query.IQueryProvider>();
             provider.GetCommandForCurrentTransaction().Returns(a => { return new SqlCommand(); });
@@ -349,7 +349,7 @@ SELECT * FROM @OutputTable;";
             return new CommandGenerator<Foo>(GetFooTableInfo(), provider, query);
         }
 
-        private CommandGenerator<Foo> GetUpsertFooGenerator()
+        private static CommandGenerator<Foo> GetUpsertFooGenerator()
         {
             KORM.Query.IQueryProvider provider = Substitute.For<KORM.Query.IQueryProvider>();
             provider.GetCommandForCurrentTransaction().Returns(a => { return new SqlCommand(); });
@@ -359,10 +359,10 @@ SELECT * FROM @OutputTable;";
             return new CommandGenerator<Foo>(GetFooTableInfo(), provider, query);
         }
 
-        private IQuery<Foo> CreateFooQuery()
+        private static IQuery<Foo> CreateFooQuery()
             => CreateQuery<Foo>();
 
-        private IQuery<T> CreateQuery<T>()
+        private static IQuery<T> CreateQuery<T>()
         {
             var query = new Query<T>(
                 new DatabaseMapper(new ConventionModelMapper()),
@@ -376,11 +376,11 @@ SELECT * FROM @OutputTable;";
             return query;
         }
 
-        private TableInfo GetFooTableInfo(
+        private static TableInfo GetFooTableInfo(
             ValueGenerated valueGenerated = ValueGenerated.OnUpdate)
             => GetFooTableInfo(true, valueGenerated);
 
-        private TableInfo GetFooTableInfo(
+        private static TableInfo GetFooTableInfo(
             bool withIdRow,
             ValueGenerated valueGenerated = ValueGenerated.OnUpdate)
         {
@@ -410,7 +410,7 @@ SELECT * FROM @OutputTable;";
             return new TableInfo(columns, new List<PropertyInfo>(), null) { Name = "Foo" };
         }
 
-        private CommandGenerator<FooPrimaryKeys> GetFooPrimaryKeyGenerator()
+        private static CommandGenerator<FooPrimaryKeys> GetFooPrimaryKeyGenerator()
         {
             KORM.Query.IQueryProvider provider = Substitute.For<KORM.Query.IQueryProvider>();
             provider.GetCommandForCurrentTransaction().Returns(a => { return new SqlCommand(); });
@@ -421,7 +421,7 @@ SELECT * FROM @OutputTable;";
             return new CommandGenerator<FooPrimaryKeys>(tableInfo, provider, query);
         }
 
-        private CommandGenerator<FooIdentity> GetFooIdentityGenerator()
+        private static CommandGenerator<FooIdentity> GetFooIdentityGenerator()
         {
             KORM.Query.IQueryProvider provider = Substitute.For<KORM.Query.IQueryProvider>();
             provider.GetCommandForCurrentTransaction().Returns(a => { return new SqlCommand(); });
@@ -431,7 +431,7 @@ SELECT * FROM @OutputTable;";
             return new CommandGenerator<FooIdentity>(GetFooIdentityTableInfo(), provider, query);
         }
 
-        private IQuery<FooIdentity> CreateFooIdentityQuery()
+        private static IQuery<FooIdentity> CreateFooIdentityQuery()
         {
             var query = new Query<FooIdentity>(
                 new DatabaseMapper(new ConventionModelMapper()),
@@ -445,7 +445,7 @@ SELECT * FROM @OutputTable;";
             return query;
         }
 
-        private TableInfo GetFooIdentityTableInfo()
+        private static TableInfo GetFooIdentityTableInfo()
         {
             var columns = new List<ColumnInfo>() {
                 new ColumnInfo() { Name = "IdRow", PropertyInfo = GetPropertyInfo<Foo>("Id"),
@@ -456,9 +456,9 @@ SELECT * FROM @OutputTable;";
             return new TableInfo(columns, new List<PropertyInfo>(), null) { Name = "FooIdentity" };
         }
 
-        private PropertyInfo GetPropertyInfo<T>(string propertyName) => typeof(T).GetProperty(propertyName);
+        private static PropertyInfo GetPropertyInfo<T>(string propertyName) => typeof(T).GetProperty(propertyName);
 
-        private TableInfo CreateTableInfoFromDto<T>()
+        private static TableInfo CreateTableInfoFromDto<T>()
         {
             var columns = new List<ColumnInfo>();
             foreach (PropertyInfo property in typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance))
@@ -476,7 +476,7 @@ SELECT * FROM @OutputTable;";
             };
         }
 
-        private CommandGenerator<T> CreateCommandGenerator<T>(TableInfo tableInfo)
+        private static CommandGenerator<T> CreateCommandGenerator<T>(TableInfo tableInfo)
         {
             IDatabaseMapper mapper = Substitute.For<IDatabaseMapper>();
             mapper.GetTableInfo<T>().Returns(tableInfo);

--- a/tests/Kros.KORM.UnitTests/Converter/NullValuesInDatabaseShould.cs
+++ b/tests/Kros.KORM.UnitTests/Converter/NullValuesInDatabaseShould.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Kros.KORM.Converter;
 using Kros.KORM.Materializer;
 using Kros.KORM.Metadata;
@@ -291,21 +291,21 @@ namespace Kros.KORM.UnitTests.Converter
             TestDataEnum CustomEnumVal = InitialDataSource.CustomEnumVal,
             TestDataEnumWithoutZero CustomEnumWithoutZeroVal = InitialDataSource.CustomEnumWithoutZeroVal,
 
-            bool? NullableBoolVal = InitialDataSource.BoolVal,
-            byte? NullableByteVal = InitialDataSource.ByteVal,
-            sbyte? NullableSByteVal = InitialDataSource.SByteVal,
-            short? NullableInt16Val = InitialDataSource.Int16Val,
-            ushort? NullableUInt16Val = InitialDataSource.UInt16Val,
-            int? NullableInt32Val = InitialDataSource.Int32Val,
-            uint? NullableUInt32Val = InitialDataSource.UInt32Val,
-            long? NullableInt64Val = InitialDataSource.Int64Val,
-            ulong? NullableUInt64Val = InitialDataSource.UInt64Val,
-            char? NullableCharVal = InitialDataSource.CharVal,
-            double? NullableDoubleVal = InitialDataSource.DoubleVal,
-            float? NullableSingleVal = InitialDataSource.SingleVal,
-            decimal? NullableDecimalVal = InitialDataSource.DecimalVal,
-            TestDataEnum? NullableCustomEnumVal = InitialDataSource.CustomEnumVal,
-            TestDataEnumWithoutZero? NullableCustomEnumWithoutZeroVal = InitialDataSource.CustomEnumWithoutZeroVal,
+            //bool? NullableBoolVal = InitialDataSource.BoolVal,
+            //byte? NullableByteVal = InitialDataSource.ByteVal,
+            //sbyte? NullableSByteVal = InitialDataSource.SByteVal,
+            //short? NullableInt16Val = InitialDataSource.Int16Val,
+            //ushort? NullableUInt16Val = InitialDataSource.UInt16Val,
+            //int? NullableInt32Val = InitialDataSource.Int32Val,
+            //uint? NullableUInt32Val = InitialDataSource.UInt32Val,
+            //long? NullableInt64Val = InitialDataSource.Int64Val,
+            //ulong? NullableUInt64Val = InitialDataSource.UInt64Val,
+            //char? NullableCharVal = InitialDataSource.CharVal,
+            //double? NullableDoubleVal = InitialDataSource.DoubleVal,
+            //float? NullableSingleVal = InitialDataSource.SingleVal,
+            //decimal? NullableDecimalVal = InitialDataSource.DecimalVal,
+            //TestDataEnum? NullableCustomEnumVal = InitialDataSource.CustomEnumVal,
+            //TestDataEnumWithoutZero? NullableCustomEnumWithoutZeroVal = InitialDataSource.CustomEnumWithoutZeroVal,
 
             string StrVal = InitialDataSource.StringVal
         )
@@ -327,21 +327,21 @@ namespace Kros.KORM.UnitTests.Converter
                 DecimalVal = 0,
                 CustomEnumVal = TestDataEnum.Zero,
                 CustomEnumWithoutZeroVal = (TestDataEnumWithoutZero)0,
-                NullableBoolVal = null,
-                NullableByteVal = null,
-                NullableSByteVal = null,
-                NullableInt16Val = null,
-                NullableUInt16Val = null,
-                NullableInt32Val = null,
-                NullableUInt32Val = null,
-                NullableInt64Val = null,
-                NullableUInt64Val = null,
-                NullableCharVal = null,
-                NullableDoubleVal = null,
-                NullableSingleVal = null,
-                NullableDecimalVal = null,
-                NullableCustomEnumVal = null,
-                NullableCustomEnumWithoutZeroVal = null,
+                //NullableBoolVal = null,
+                //NullableByteVal = null,
+                //NullableSByteVal = null,
+                //NullableInt16Val = null,
+                //NullableUInt16Val = null,
+                //NullableInt32Val = null,
+                //NullableUInt32Val = null,
+                //NullableInt64Val = null,
+                //NullableUInt64Val = null,
+                //NullableCharVal = null,
+                //NullableDoubleVal = null,
+                //NullableSingleVal = null,
+                //NullableDecimalVal = null,
+                //NullableCustomEnumVal = null,
+                //NullableCustomEnumWithoutZeroVal = null,
                 StrVal = null
             };
 
@@ -363,21 +363,21 @@ namespace Kros.KORM.UnitTests.Converter
                 CustomEnumVal = DbDataSource.CustomEnumVal,
                 CustomEnumWithoutZeroVal = DbDataSource.CustomEnumWithoutZeroVal,
 
-                NullableBoolVal = DbDataSource.BoolVal,
-                NullableByteVal = DbDataSource.ByteVal,
-                NullableSByteVal = DbDataSource.SByteVal,
-                NullableInt16Val = DbDataSource.Int16Val,
-                NullableUInt16Val = DbDataSource.UInt16Val,
-                NullableInt32Val = DbDataSource.Int32Val,
-                NullableUInt32Val = DbDataSource.UInt32Val,
-                NullableInt64Val = DbDataSource.Int64Val,
-                NullableUInt64Val = DbDataSource.UInt64Val,
-                NullableCharVal = DbDataSource.CharVal,
-                NullableDoubleVal = DbDataSource.DoubleVal,
-                NullableSingleVal = DbDataSource.SingleVal,
-                NullableDecimalVal = DbDataSource.DecimalVal,
-                NullableCustomEnumVal = DbDataSource.CustomEnumVal,
-                NullableCustomEnumWithoutZeroVal = DbDataSource.CustomEnumWithoutZeroVal,
+                //NullableBoolVal = DbDataSource.BoolVal,
+                //NullableByteVal = DbDataSource.ByteVal,
+                //NullableSByteVal = DbDataSource.SByteVal,
+                //NullableInt16Val = DbDataSource.Int16Val,
+                //NullableUInt16Val = DbDataSource.UInt16Val,
+                //NullableInt32Val = DbDataSource.Int32Val,
+                //NullableUInt32Val = DbDataSource.UInt32Val,
+                //NullableInt64Val = DbDataSource.Int64Val,
+                //NullableUInt64Val = DbDataSource.UInt64Val,
+                //NullableCharVal = DbDataSource.CharVal,
+                //NullableDoubleVal = DbDataSource.DoubleVal,
+                //NullableSingleVal = DbDataSource.SingleVal,
+                //NullableDecimalVal = DbDataSource.DecimalVal,
+                //NullableCustomEnumVal = DbDataSource.CustomEnumVal,
+                //NullableCustomEnumWithoutZeroVal = DbDataSource.CustomEnumWithoutZeroVal,
 
                 StrVal = DbDataSource.StringVal
             };
@@ -448,10 +448,10 @@ namespace Kros.KORM.UnitTests.Converter
             Two
         }
 
-        private enum TestDataEnumWithoutZero
+        private enum TestDataEnumWithoutZero : long
         {
-            Ten = 10,
-            Twenty = 20
+            Ten = 10_000_000_000,
+            Twenty = 20_000_000_000
         }
 
         private class TestConverter : IConverter

--- a/tests/Kros.KORM.UnitTests/Converter/NullValuesInDatabaseShould.cs
+++ b/tests/Kros.KORM.UnitTests/Converter/NullValuesInDatabaseShould.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Kros.KORM.Converter;
 using Kros.KORM.Materializer;
 using Kros.KORM.Metadata;
@@ -57,6 +57,23 @@ namespace Kros.KORM.UnitTests.Converter
             TestDataRecord expected = simulateDbNull
                 ? TestDataRecord.CreateWithNulledProperties()
                 : TestDataRecord.CreateWithDbValuesProperties();
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void PropagateToDataRecord_NoConstructor(bool simulateDbNull)
+        {
+            TestDataHelper<TestDataRecord_NoConstructor, TestDataRecord_NoConstructor> info
+                = new(simulateDbNull: simulateDbNull, useConverter: false);
+            DynamicMethodModelFactory modelFactory = new(info.DatabaseMapper);
+            Func<IDataReader, TestDataRecord_NoConstructor> factory = modelFactory.GetFactory<TestDataRecord_NoConstructor>(info.DataReader);
+
+            TestDataRecord_NoConstructor actual = factory(info.DataReader);
+            TestDataRecord_NoConstructor expected = simulateDbNull
+                ? TestDataRecord_NoConstructor.CreateWithNulledProperties()
+                : TestDataRecord_NoConstructor.CreateWithDbValuesProperties();
             actual.Should().BeEquivalentTo(expected);
         }
 
@@ -291,21 +308,21 @@ namespace Kros.KORM.UnitTests.Converter
             TestDataEnum CustomEnumVal = InitialDataSource.CustomEnumVal,
             TestDataEnumWithoutZero CustomEnumWithoutZeroVal = InitialDataSource.CustomEnumWithoutZeroVal,
 
-            //bool? NullableBoolVal = InitialDataSource.BoolVal,
-            //byte? NullableByteVal = InitialDataSource.ByteVal,
-            //sbyte? NullableSByteVal = InitialDataSource.SByteVal,
-            //short? NullableInt16Val = InitialDataSource.Int16Val,
-            //ushort? NullableUInt16Val = InitialDataSource.UInt16Val,
-            //int? NullableInt32Val = InitialDataSource.Int32Val,
-            //uint? NullableUInt32Val = InitialDataSource.UInt32Val,
-            //long? NullableInt64Val = InitialDataSource.Int64Val,
-            //ulong? NullableUInt64Val = InitialDataSource.UInt64Val,
-            //char? NullableCharVal = InitialDataSource.CharVal,
-            //double? NullableDoubleVal = InitialDataSource.DoubleVal,
-            //float? NullableSingleVal = InitialDataSource.SingleVal,
-            //decimal? NullableDecimalVal = InitialDataSource.DecimalVal,
-            //TestDataEnum? NullableCustomEnumVal = InitialDataSource.CustomEnumVal,
-            //TestDataEnumWithoutZero? NullableCustomEnumWithoutZeroVal = InitialDataSource.CustomEnumWithoutZeroVal,
+            bool? NullableBoolVal = InitialDataSource.BoolVal,
+            byte? NullableByteVal = InitialDataSource.ByteVal,
+            sbyte? NullableSByteVal = InitialDataSource.SByteVal,
+            short? NullableInt16Val = InitialDataSource.Int16Val,
+            ushort? NullableUInt16Val = InitialDataSource.UInt16Val,
+            int? NullableInt32Val = InitialDataSource.Int32Val,
+            uint? NullableUInt32Val = InitialDataSource.UInt32Val,
+            long? NullableInt64Val = InitialDataSource.Int64Val,
+            ulong? NullableUInt64Val = InitialDataSource.UInt64Val,
+            char? NullableCharVal = InitialDataSource.CharVal,
+            double? NullableDoubleVal = InitialDataSource.DoubleVal,
+            float? NullableSingleVal = InitialDataSource.SingleVal,
+            decimal? NullableDecimalVal = InitialDataSource.DecimalVal,
+            TestDataEnum? NullableCustomEnumVal = InitialDataSource.CustomEnumVal,
+            TestDataEnumWithoutZero? NullableCustomEnumWithoutZeroVal = InitialDataSource.CustomEnumWithoutZeroVal,
 
             string StrVal = InitialDataSource.StringVal
         )
@@ -327,21 +344,21 @@ namespace Kros.KORM.UnitTests.Converter
                 DecimalVal = 0,
                 CustomEnumVal = TestDataEnum.Zero,
                 CustomEnumWithoutZeroVal = (TestDataEnumWithoutZero)0,
-                //NullableBoolVal = null,
-                //NullableByteVal = null,
-                //NullableSByteVal = null,
-                //NullableInt16Val = null,
-                //NullableUInt16Val = null,
-                //NullableInt32Val = null,
-                //NullableUInt32Val = null,
-                //NullableInt64Val = null,
-                //NullableUInt64Val = null,
-                //NullableCharVal = null,
-                //NullableDoubleVal = null,
-                //NullableSingleVal = null,
-                //NullableDecimalVal = null,
-                //NullableCustomEnumVal = null,
-                //NullableCustomEnumWithoutZeroVal = null,
+                NullableBoolVal = null,
+                NullableByteVal = null,
+                NullableSByteVal = null,
+                NullableInt16Val = null,
+                NullableUInt16Val = null,
+                NullableInt32Val = null,
+                NullableUInt32Val = null,
+                NullableInt64Val = null,
+                NullableUInt64Val = null,
+                NullableCharVal = null,
+                NullableDoubleVal = null,
+                NullableSingleVal = null,
+                NullableDecimalVal = null,
+                NullableCustomEnumVal = null,
+                NullableCustomEnumWithoutZeroVal = null,
                 StrVal = null
             };
 
@@ -363,21 +380,128 @@ namespace Kros.KORM.UnitTests.Converter
                 CustomEnumVal = DbDataSource.CustomEnumVal,
                 CustomEnumWithoutZeroVal = DbDataSource.CustomEnumWithoutZeroVal,
 
-                //NullableBoolVal = DbDataSource.BoolVal,
-                //NullableByteVal = DbDataSource.ByteVal,
-                //NullableSByteVal = DbDataSource.SByteVal,
-                //NullableInt16Val = DbDataSource.Int16Val,
-                //NullableUInt16Val = DbDataSource.UInt16Val,
-                //NullableInt32Val = DbDataSource.Int32Val,
-                //NullableUInt32Val = DbDataSource.UInt32Val,
-                //NullableInt64Val = DbDataSource.Int64Val,
-                //NullableUInt64Val = DbDataSource.UInt64Val,
-                //NullableCharVal = DbDataSource.CharVal,
-                //NullableDoubleVal = DbDataSource.DoubleVal,
-                //NullableSingleVal = DbDataSource.SingleVal,
-                //NullableDecimalVal = DbDataSource.DecimalVal,
-                //NullableCustomEnumVal = DbDataSource.CustomEnumVal,
-                //NullableCustomEnumWithoutZeroVal = DbDataSource.CustomEnumWithoutZeroVal,
+                NullableBoolVal = DbDataSource.BoolVal,
+                NullableByteVal = DbDataSource.ByteVal,
+                NullableSByteVal = DbDataSource.SByteVal,
+                NullableInt16Val = DbDataSource.Int16Val,
+                NullableUInt16Val = DbDataSource.UInt16Val,
+                NullableInt32Val = DbDataSource.Int32Val,
+                NullableUInt32Val = DbDataSource.UInt32Val,
+                NullableInt64Val = DbDataSource.Int64Val,
+                NullableUInt64Val = DbDataSource.UInt64Val,
+                NullableCharVal = DbDataSource.CharVal,
+                NullableDoubleVal = DbDataSource.DoubleVal,
+                NullableSingleVal = DbDataSource.SingleVal,
+                NullableDecimalVal = DbDataSource.DecimalVal,
+                NullableCustomEnumVal = DbDataSource.CustomEnumVal,
+                NullableCustomEnumWithoutZeroVal = DbDataSource.CustomEnumWithoutZeroVal,
+
+                StrVal = DbDataSource.StringVal
+            };
+        }
+
+        private record TestDataRecord_NoConstructor
+        {
+            public bool BoolVal { get; set; } = InitialDataSource.BoolVal;
+            public byte ByteVal { get; set; } = InitialDataSource.ByteVal;
+            public sbyte SByteVal { get; set; } = InitialDataSource.SByteVal;
+            public short Int16Val { get; set; } = InitialDataSource.Int16Val;
+            public ushort UInt16Val { get; set; } = InitialDataSource.UInt16Val;
+            public int Int32Val { get; set; } = InitialDataSource.Int32Val;
+            public uint UInt32Val { get; set; } = InitialDataSource.UInt32Val;
+            public long Int64Val { get; set; } = InitialDataSource.Int64Val;
+            public ulong UInt64Val { get; set; } = InitialDataSource.UInt64Val;
+            public char CharVal { get; set; } = InitialDataSource.CharVal;
+            public double DoubleVal { get; set; } = InitialDataSource.DoubleVal;
+            public float SingleVal { get; set; } = InitialDataSource.SingleVal;
+            public decimal DecimalVal { get; set; } = InitialDataSource.DecimalVal;
+            public TestDataEnum CustomEnumVal { get; set; } = InitialDataSource.CustomEnumVal;
+            public TestDataEnumWithoutZero CustomEnumWithoutZeroVal { get; set; } = InitialDataSource.CustomEnumWithoutZeroVal;
+            public bool? NullableBoolVal { get; set; } = InitialDataSource.BoolVal;
+            public byte? NullableByteVal { get; set; } = InitialDataSource.ByteVal;
+            public sbyte? NullableSByteVal { get; set; } = InitialDataSource.SByteVal;
+            public short? NullableInt16Val { get; set; } = InitialDataSource.Int16Val;
+            public ushort? NullableUInt16Val { get; set; } = InitialDataSource.UInt16Val;
+            public int? NullableInt32Val { get; set; } = InitialDataSource.Int32Val;
+            public uint? NullableUInt32Val { get; set; } = InitialDataSource.UInt32Val;
+            public long? NullableInt64Val { get; set; } = InitialDataSource.Int64Val;
+            public ulong? NullableUInt64Val { get; set; } = InitialDataSource.UInt64Val;
+            public char? NullableCharVal { get; set; } = InitialDataSource.CharVal;
+            public double? NullableDoubleVal { get; set; } = InitialDataSource.DoubleVal;
+            public float? NullableSingleVal { get; set; } = InitialDataSource.SingleVal;
+            public decimal? NullableDecimalVal { get; set; } = InitialDataSource.DecimalVal;
+            public TestDataEnum? NullableCustomEnumVal { get; set; } = InitialDataSource.CustomEnumVal;
+            public TestDataEnumWithoutZero? NullableCustomEnumWithoutZeroVal { get; set; } = InitialDataSource.CustomEnumWithoutZeroVal;
+            public string StrVal { get; set; } = InitialDataSource.StringVal;
+
+            public static TestDataRecord_NoConstructor CreateWithNulledProperties() => new()
+            {
+                BoolVal = false,
+                ByteVal = 0,
+                SByteVal = 0,
+                Int16Val = 0,
+                UInt16Val = 0,
+                Int32Val = 0,
+                UInt32Val = 0,
+                Int64Val = 0,
+                UInt64Val = 0,
+                CharVal = '\0',
+                DoubleVal = 0,
+                SingleVal = 0,
+                DecimalVal = 0,
+                CustomEnumVal = TestDataEnum.Zero,
+                CustomEnumWithoutZeroVal = (TestDataEnumWithoutZero)0,
+                NullableBoolVal = null,
+                NullableByteVal = null,
+                NullableSByteVal = null,
+                NullableInt16Val = null,
+                NullableUInt16Val = null,
+                NullableInt32Val = null,
+                NullableUInt32Val = null,
+                NullableInt64Val = null,
+                NullableUInt64Val = null,
+                NullableCharVal = null,
+                NullableDoubleVal = null,
+                NullableSingleVal = null,
+                NullableDecimalVal = null,
+                NullableCustomEnumVal = null,
+                NullableCustomEnumWithoutZeroVal = null,
+                StrVal = null
+            };
+
+            public static TestDataRecord_NoConstructor CreateWithDbValuesProperties() => new()
+            {
+                BoolVal = DbDataSource.BoolVal,
+                ByteVal = DbDataSource.ByteVal,
+                SByteVal = DbDataSource.SByteVal,
+                Int16Val = DbDataSource.Int16Val,
+                UInt16Val = DbDataSource.UInt16Val,
+                Int32Val = DbDataSource.Int32Val,
+                UInt32Val = DbDataSource.UInt32Val,
+                Int64Val = DbDataSource.Int64Val,
+                UInt64Val = DbDataSource.UInt64Val,
+                CharVal = DbDataSource.CharVal,
+                DoubleVal = DbDataSource.DoubleVal,
+                SingleVal = DbDataSource.SingleVal,
+                DecimalVal = DbDataSource.DecimalVal,
+                CustomEnumVal = DbDataSource.CustomEnumVal,
+                CustomEnumWithoutZeroVal = DbDataSource.CustomEnumWithoutZeroVal,
+
+                NullableBoolVal = DbDataSource.BoolVal,
+                NullableByteVal = DbDataSource.ByteVal,
+                NullableSByteVal = DbDataSource.SByteVal,
+                NullableInt16Val = DbDataSource.Int16Val,
+                NullableUInt16Val = DbDataSource.UInt16Val,
+                NullableInt32Val = DbDataSource.Int32Val,
+                NullableUInt32Val = DbDataSource.UInt32Val,
+                NullableInt64Val = DbDataSource.Int64Val,
+                NullableUInt64Val = DbDataSource.UInt64Val,
+                NullableCharVal = DbDataSource.CharVal,
+                NullableDoubleVal = DbDataSource.DoubleVal,
+                NullableSingleVal = DbDataSource.SingleVal,
+                NullableDecimalVal = DbDataSource.DecimalVal,
+                NullableCustomEnumVal = DbDataSource.CustomEnumVal,
+                NullableCustomEnumWithoutZeroVal = DbDataSource.CustomEnumWithoutZeroVal,
 
                 StrVal = DbDataSource.StringVal
             };

--- a/tests/Kros.KORM.UnitTests/Converter/NullValuesInDatabaseShould.cs
+++ b/tests/Kros.KORM.UnitTests/Converter/NullValuesInDatabaseShould.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Kros.KORM.Converter;
 using Kros.KORM.Materializer;
 using Kros.KORM.Metadata;
@@ -57,23 +57,6 @@ namespace Kros.KORM.UnitTests.Converter
             TestDataRecord expected = simulateDbNull
                 ? TestDataRecord.CreateWithNulledProperties()
                 : TestDataRecord.CreateWithDbValuesProperties();
-            actual.Should().BeEquivalentTo(expected);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void PropagateToDataRecord_NoConstructor(bool simulateDbNull)
-        {
-            TestDataHelper<TestDataRecord_NoConstructor, TestDataRecord_NoConstructor> info
-                = new(simulateDbNull: simulateDbNull, useConverter: false);
-            DynamicMethodModelFactory modelFactory = new(info.DatabaseMapper);
-            Func<IDataReader, TestDataRecord_NoConstructor> factory = modelFactory.GetFactory<TestDataRecord_NoConstructor>(info.DataReader);
-
-            TestDataRecord_NoConstructor actual = factory(info.DataReader);
-            TestDataRecord_NoConstructor expected = simulateDbNull
-                ? TestDataRecord_NoConstructor.CreateWithNulledProperties()
-                : TestDataRecord_NoConstructor.CreateWithDbValuesProperties();
             actual.Should().BeEquivalentTo(expected);
         }
 
@@ -363,113 +346,6 @@ namespace Kros.KORM.UnitTests.Converter
             };
 
             public static TestDataRecord CreateWithDbValuesProperties() => new()
-            {
-                BoolVal = DbDataSource.BoolVal,
-                ByteVal = DbDataSource.ByteVal,
-                SByteVal = DbDataSource.SByteVal,
-                Int16Val = DbDataSource.Int16Val,
-                UInt16Val = DbDataSource.UInt16Val,
-                Int32Val = DbDataSource.Int32Val,
-                UInt32Val = DbDataSource.UInt32Val,
-                Int64Val = DbDataSource.Int64Val,
-                UInt64Val = DbDataSource.UInt64Val,
-                CharVal = DbDataSource.CharVal,
-                DoubleVal = DbDataSource.DoubleVal,
-                SingleVal = DbDataSource.SingleVal,
-                DecimalVal = DbDataSource.DecimalVal,
-                CustomEnumVal = DbDataSource.CustomEnumVal,
-                CustomEnumWithoutZeroVal = DbDataSource.CustomEnumWithoutZeroVal,
-
-                NullableBoolVal = DbDataSource.BoolVal,
-                NullableByteVal = DbDataSource.ByteVal,
-                NullableSByteVal = DbDataSource.SByteVal,
-                NullableInt16Val = DbDataSource.Int16Val,
-                NullableUInt16Val = DbDataSource.UInt16Val,
-                NullableInt32Val = DbDataSource.Int32Val,
-                NullableUInt32Val = DbDataSource.UInt32Val,
-                NullableInt64Val = DbDataSource.Int64Val,
-                NullableUInt64Val = DbDataSource.UInt64Val,
-                NullableCharVal = DbDataSource.CharVal,
-                NullableDoubleVal = DbDataSource.DoubleVal,
-                NullableSingleVal = DbDataSource.SingleVal,
-                NullableDecimalVal = DbDataSource.DecimalVal,
-                NullableCustomEnumVal = DbDataSource.CustomEnumVal,
-                NullableCustomEnumWithoutZeroVal = DbDataSource.CustomEnumWithoutZeroVal,
-
-                StrVal = DbDataSource.StringVal
-            };
-        }
-
-        private record TestDataRecord_NoConstructor
-        {
-            public bool BoolVal { get; set; } = InitialDataSource.BoolVal;
-            public byte ByteVal { get; set; } = InitialDataSource.ByteVal;
-            public sbyte SByteVal { get; set; } = InitialDataSource.SByteVal;
-            public short Int16Val { get; set; } = InitialDataSource.Int16Val;
-            public ushort UInt16Val { get; set; } = InitialDataSource.UInt16Val;
-            public int Int32Val { get; set; } = InitialDataSource.Int32Val;
-            public uint UInt32Val { get; set; } = InitialDataSource.UInt32Val;
-            public long Int64Val { get; set; } = InitialDataSource.Int64Val;
-            public ulong UInt64Val { get; set; } = InitialDataSource.UInt64Val;
-            public char CharVal { get; set; } = InitialDataSource.CharVal;
-            public double DoubleVal { get; set; } = InitialDataSource.DoubleVal;
-            public float SingleVal { get; set; } = InitialDataSource.SingleVal;
-            public decimal DecimalVal { get; set; } = InitialDataSource.DecimalVal;
-            public TestDataEnum CustomEnumVal { get; set; } = InitialDataSource.CustomEnumVal;
-            public TestDataEnumWithoutZero CustomEnumWithoutZeroVal { get; set; } = InitialDataSource.CustomEnumWithoutZeroVal;
-            public bool? NullableBoolVal { get; set; } = InitialDataSource.BoolVal;
-            public byte? NullableByteVal { get; set; } = InitialDataSource.ByteVal;
-            public sbyte? NullableSByteVal { get; set; } = InitialDataSource.SByteVal;
-            public short? NullableInt16Val { get; set; } = InitialDataSource.Int16Val;
-            public ushort? NullableUInt16Val { get; set; } = InitialDataSource.UInt16Val;
-            public int? NullableInt32Val { get; set; } = InitialDataSource.Int32Val;
-            public uint? NullableUInt32Val { get; set; } = InitialDataSource.UInt32Val;
-            public long? NullableInt64Val { get; set; } = InitialDataSource.Int64Val;
-            public ulong? NullableUInt64Val { get; set; } = InitialDataSource.UInt64Val;
-            public char? NullableCharVal { get; set; } = InitialDataSource.CharVal;
-            public double? NullableDoubleVal { get; set; } = InitialDataSource.DoubleVal;
-            public float? NullableSingleVal { get; set; } = InitialDataSource.SingleVal;
-            public decimal? NullableDecimalVal { get; set; } = InitialDataSource.DecimalVal;
-            public TestDataEnum? NullableCustomEnumVal { get; set; } = InitialDataSource.CustomEnumVal;
-            public TestDataEnumWithoutZero? NullableCustomEnumWithoutZeroVal { get; set; } = InitialDataSource.CustomEnumWithoutZeroVal;
-            public string StrVal { get; set; } = InitialDataSource.StringVal;
-
-            public static TestDataRecord_NoConstructor CreateWithNulledProperties() => new()
-            {
-                BoolVal = false,
-                ByteVal = 0,
-                SByteVal = 0,
-                Int16Val = 0,
-                UInt16Val = 0,
-                Int32Val = 0,
-                UInt32Val = 0,
-                Int64Val = 0,
-                UInt64Val = 0,
-                CharVal = '\0',
-                DoubleVal = 0,
-                SingleVal = 0,
-                DecimalVal = 0,
-                CustomEnumVal = TestDataEnum.Zero,
-                CustomEnumWithoutZeroVal = (TestDataEnumWithoutZero)0,
-                NullableBoolVal = null,
-                NullableByteVal = null,
-                NullableSByteVal = null,
-                NullableInt16Val = null,
-                NullableUInt16Val = null,
-                NullableInt32Val = null,
-                NullableUInt32Val = null,
-                NullableInt64Val = null,
-                NullableUInt64Val = null,
-                NullableCharVal = null,
-                NullableDoubleVal = null,
-                NullableSingleVal = null,
-                NullableDecimalVal = null,
-                NullableCustomEnumVal = null,
-                NullableCustomEnumWithoutZeroVal = null,
-                StrVal = null
-            };
-
-            public static TestDataRecord_NoConstructor CreateWithDbValuesProperties() => new()
             {
                 BoolVal = DbDataSource.BoolVal,
                 ByteVal = DbDataSource.ByteVal,

--- a/tests/Kros.KORM.UnitTests/Kros.KORM.UnitTests.csproj
+++ b/tests/Kros.KORM.UnitTests/Kros.KORM.UnitTests.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.10.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Nito.AsyncEx.Context" Version="5.1.2" />
-    <PackageReference Include="NSubstitute" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/Kros.KORM.VB.UnitTests/Kros.KORM.VB.UnitTests.vbproj
+++ b/tests/Kros.KORM.VB.UnitTests/Kros.KORM.VB.UnitTests.vbproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.10.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- Upgrade to .NET 8.
- Resolved minor issues

## Changes in generating dynamic methods

These changes were necessary because in .NET 8 the program was crashing when generating dynamic methods.

- Fixed generating values for `decimal` and `enum` types: `ILGeneratorHelper.cs`
- Fixed using local variables in dynamic methods: `DynamicMethodModelFactory.cs`, `RecordModelFactory.cs`