### PR TITLE
Post-migration actions and post-migration database views refreshing

### DIFF
--- a/src/Kros.KORM.csproj
+++ b/src/Kros.KORM.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Version>7.0.0</Version>
+    <Version>7.1.0</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>KORM is fast, easy to use, micro ORM tool (Kros Object Relation Mapper).</Description>

--- a/src/Migrations/MigrationsRunner.cs
+++ b/src/Migrations/MigrationsRunner.cs
@@ -88,6 +88,7 @@ namespace Kros.KORM.Migrations
                         try
                         {
                             await action(helper.Database);
+                            //VYMAZAť
                             Console.WriteLine("Post-migration action(s) executed.");
                         }
                         catch (Exception ex)

--- a/src/Migrations/MigrationsRunner.cs
+++ b/src/Migrations/MigrationsRunner.cs
@@ -82,19 +82,11 @@ namespace Kros.KORM.Migrations
                 if (migrationScripts.Any())
                 {
                     await ExecuteMigrationScripts(helper.Database, migrationScripts);
+                    long maxScriptId = migrationScripts.Max(s => s.Id);
 
                     foreach (var action in _migrationOptions.Actions)
                     {
-                        try
-                        {
-                            await action(helper.Database);
-                            //VYMAZAť
-                            Console.WriteLine("Post-migration action(s) executed.");
-                        }
-                        catch (Exception ex)
-                        {
-                            Console.WriteLine($"Error executing post-migration action(s): {ex.Message}");
-                        }
+                        await action(helper.Database, maxScriptId);
                     }
                 }
             }

--- a/src/Migrations/MigrationsRunner.cs
+++ b/src/Migrations/MigrationsRunner.cs
@@ -82,6 +82,19 @@ namespace Kros.KORM.Migrations
                 if (migrationScripts.Any())
                 {
                     await ExecuteMigrationScripts(helper.Database, migrationScripts);
+
+                    foreach (var action in _migrationOptions.Actions)
+                    {
+                        try
+                        {
+                            await action(helper.Database);
+                            Console.WriteLine("Post-migration action(s) executed.");
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine($"Error executing post-migration action(s): {ex.Message}");
+                        }
+                    }
                 }
             }
         }

--- a/src/Resources/RefreshViews.sql
+++ b/src/Resources/RefreshViews.sql
@@ -1,15 +1,8 @@
-﻿DECLARE @viewName NVARCHAR(128)
-DECLARE viewCursor CURSOR FOR
-SELECT name FROM sys.views
+﻿DECLARE @sql NVARCHAR(MAX)
 
-OPEN viewCursor
-FETCH NEXT FROM viewCursor INTO @viewName
+SET @sql = (
+    SELECT STRING_AGG('EXEC sp_refreshview ' + QUOTENAME(name), '; ') 
+    FROM sys.views
+)
 
-WHILE @@FETCH_STATUS = 0
-BEGIN
-    EXEC sp_refreshview @viewName
-    FETCH NEXT FROM viewCursor INTO @viewName
-END
-
-CLOSE viewCursor
-DEALLOCATE viewCursor
+EXEC sp_executesql @sql

--- a/src/Resources/RefreshViews.sql
+++ b/src/Resources/RefreshViews.sql
@@ -1,0 +1,15 @@
+﻿DECLARE @viewName NVARCHAR(128)
+DECLARE viewCursor CURSOR FOR
+SELECT name FROM sys.views
+
+OPEN viewCursor
+FETCH NEXT FROM viewCursor INTO @viewName
+
+WHILE @@FETCH_STATUS = 0
+BEGIN
+    EXEC sp_refreshview @viewName
+    FETCH NEXT FROM viewCursor INTO @viewName
+END
+
+CLOSE viewCursor
+DEALLOCATE viewCursor


### PR DESCRIPTION
Added post-migration actions and post-migration database views refresh with an option to accept the script ID up to which actions will be executed after migration. Added default script for refreshing views into resources.

Use:
```c
const long scriptId = 20251912010;

builder.Services.AddKorm(builder.Configuration)
        .AddKormMigrations(options =>
        {
            var assembly = Assembly.GetEntryAssembly();
            options.AddAssemblyScriptsProvider(assembly, "CompanyStruct.SqlScripts");

            options.AddRefreshViewsAction();

            options.AddAfterMigrationAction(async (database, id) =>
            {
                if (id <= scriptId)
                {
                    database.ExecuteNonQuery("INSERT ...");
                }
                await Task.CompletedTask;
            });
        })
        .Migrate();
```

Action will be executed only if the ID of the latest script of the migration is less than or equal to the user-defined ID. If the ID is not defined, the action will execute regardless.