### PR TITLE
Lock access to converters and injectors in model factory dynamic methods

### DIFF
--- a/src/Kros.KORM.csproj
+++ b/src/Kros.KORM.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <Version>6.2.0</Version>
+    <Version>6.3.0</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>KORM is fast, easy to use, micro ORM tool (Kros Object Relation Mapper).</Description>

--- a/src/Materializer/ILGeneratorHelper.cs
+++ b/src/Materializer/ILGeneratorHelper.cs
@@ -12,6 +12,7 @@ namespace Kros.KORM.Materializer
 {
     internal static class ILGeneratorHelper
     {
+        private static readonly object _convertersLock = new();
         private static readonly List<IConverter> _converters = new List<IConverter>();
         private static readonly Dictionary<string, MethodInfo> _readerValueGetters = InitReaderValueGetters();
         private static readonly MethodInfo _fnIsDBNull = typeof(IDataRecord).GetMethod(nameof(IDataReader.IsDBNull));
@@ -22,6 +23,7 @@ namespace Kros.KORM.Materializer
         private static readonly MethodInfo _fnConvertersListGetItem = typeof(List<IConverter>).GetProperty("Item").GetGetMethod();
         private static readonly MethodInfo _fnGetValue = typeof(IDataRecord).GetMethod("GetValue", new Type[] { typeof(int) });
         private static readonly MethodInfo _fnConvert = typeof(IConverter).GetMethod("Convert");
+        private static readonly object _injectorsLock = new();
         private static readonly List<IInjector> _injectors = new List<IInjector>();
         private static readonly FieldInfo _fldInjectors = typeof(ILGeneratorHelper).GetField(nameof(_injectors),
             BindingFlags.Static | BindingFlags.GetField | BindingFlags.NonPublic);
@@ -226,8 +228,12 @@ namespace Kros.KORM.Materializer
             int fieldIndex,
             bool convertNullValue)
         {
-            int converterIndex = _converters.Count;
-            _converters.Add(converter);
+            int converterIndex;
+            lock (_convertersLock)
+            {
+                converterIndex = _converters.Count;
+                _converters.Add(converter);
+            }
 
             ilGenerator.LogAndEmit(OpCodes.Ldsfld, _fldConverters);
             ilGenerator.LogAndEmit(OpCodes.Ldc_I4, converterIndex);
@@ -390,8 +396,11 @@ namespace Kros.KORM.Materializer
             var injectorIndex = _injectors.IndexOf(injector);
             if (injectorIndex == -1)
             {
-                _injectors.Add(injector);
-                injectorIndex = _injectors.Count - 1;
+                lock (_injectorsLock)
+                {
+                    _injectors.Add(injector);
+                    injectorIndex = _injectors.Count - 1;
+                }
             }
 
             return injectorIndex;


### PR DESCRIPTION
This was failing in multi-threaded scenario, because 2 threds obtained index into the list and then added item to that list. After that only one index was valid.