### PR TITLE
Sequential GUIDs (Primary Key) Generation on SQL Side

### DIFF
--- a/src/Kros.KORM.csproj
+++ b/src/Kros.KORM.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <Version>7.3.0</Version>
+    <Version>7.4.0</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>KORM is fast, easy to use, micro ORM tool (Kros Object Relation Mapper).</Description>

--- a/src/Metadata/TableInfo.cs
+++ b/src/Metadata/TableInfo.cs
@@ -18,7 +18,7 @@ namespace Kros.KORM.Metadata
         private Dictionary<string, ColumnInfo> _columns;
         private Lazy<Dictionary<string, ColumnInfo>> _properties;
         private Lazy<ColumnInfo> _identityPrimaryKey;
-        private readonly IReadOnlyDictionary<Type, string> DataTypesMap =
+        private static readonly IReadOnlyDictionary<Type, string> _dataTypesMap =
             new Dictionary<Type, string>()
             {
                 { typeof(int), "int" },
@@ -122,7 +122,7 @@ namespace Kros.KORM.Metadata
         /// Gets primary key SQL data type.
         /// </summary>
         public string IdentityPrimaryKeySqlType => IdentityPrimaryKey is not null &&
-            DataTypesMap.TryGetValue(IdentityPrimaryKey.PropertyInfo.PropertyType, out string sqlType)
+            _dataTypesMap.TryGetValue(IdentityPrimaryKey.PropertyInfo.PropertyType, out string sqlType)
                 ? sqlType
                 : string.Empty;
 

--- a/src/Metadata/TableInfo.cs
+++ b/src/Metadata/TableInfo.cs
@@ -18,6 +18,13 @@ namespace Kros.KORM.Metadata
         private Dictionary<string, ColumnInfo> _columns;
         private Lazy<Dictionary<string, ColumnInfo>> _properties;
         private Lazy<ColumnInfo> _identityPrimaryKey;
+        private readonly IReadOnlyDictionary<Type, string> DataTypesMap =
+            new Dictionary<Type, string>()
+            {
+                { typeof(int), "int" },
+                { typeof(long), "bigint" },
+                { typeof(Guid), "uniqueidentifier" },
+            };
 
         #endregion
 
@@ -114,24 +121,10 @@ namespace Kros.KORM.Metadata
         /// <summary>
         /// Gets primary key SQL data type.
         /// </summary>
-        public string IdentityPrimaryKeySqlType
-        {
-            get
-            {
-                if (IdentityPrimaryKey is not null)
-                {
-                    if (IdentityPrimaryKey.PropertyInfo.PropertyType == typeof(long))
-                    {
-                        return "bigint";
-                    }
-                    else if (IdentityPrimaryKey.PropertyInfo.PropertyType == typeof(int))
-                    {
-                        return "int";
-                    }
-                }
-                return string.Empty;
-            }
-        }
+        public string IdentityPrimaryKeySqlType => IdentityPrimaryKey is not null &&
+            DataTypesMap.TryGetValue(IdentityPrimaryKey.PropertyInfo.PropertyType, out string sqlType)
+                ? sqlType
+                : string.Empty;
 
         #endregion
 

--- a/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
+++ b/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
@@ -46,6 +46,18 @@ SELECT * FROM @OutputTable;";
         }
 
         [Fact]
+        public void HaveCorrectInsertCommandTextWhenTableHaveGuidIdentityPrimaryKey()
+        {
+            const string expectedQuery = @"DECLARE @OutputTable TABLE (IdRow uniqueidentifier);
+INSERT INTO [FooGuidIdentity] ([Salary]) OUTPUT INSERTED.IdRow INTO @OutputTable VALUES (@Salary);
+SELECT * FROM @OutputTable;";
+
+            DbCommand insert = GetFooGuidIdentityGenerator().GetInsertCommand();
+
+            insert.CommandText.Should().Be(expectedQuery);
+        }
+
+        [Fact]
         public void HaveCorrectUpdateCommandText()
         {
             const string expectedQuery = "UPDATE [Foo] SET [Salary] = @Salary, [PropertyValueGenerator] = @PropertyValueGenerator WHERE ([IdRow] = @IdRow)";
@@ -359,8 +371,56 @@ SELECT * FROM @OutputTable;";
             return new CommandGenerator<Foo>(GetFooTableInfo(), provider, query);
         }
 
+        private static CommandGenerator<FooIdentity> GetFooIdentityGenerator()
+        {
+            KORM.Query.IQueryProvider provider = Substitute.For<KORM.Query.IQueryProvider>();
+            provider.GetCommandForCurrentTransaction().Returns(a => { return new SqlCommand(); });
+
+            IQuery<FooIdentity> query = CreateFooIdentityQuery();
+            query.Select(p => new { p.Id, p.Plat });
+            return new CommandGenerator<FooIdentity>(GetFooIdentityTableInfo(), provider, query);
+        }
+
+        private static CommandGenerator<FooGuidIdentity> GetFooGuidIdentityGenerator()
+        {
+            KORM.Query.IQueryProvider provider = Substitute.For<KORM.Query.IQueryProvider>();
+            provider.GetCommandForCurrentTransaction().Returns(a => { return new SqlCommand(); });
+
+            IQuery<FooGuidIdentity> query = CreateFooGuidIdentityQuery();
+            query.Select(p => new { p.Id, p.Plat });
+            return new CommandGenerator<FooGuidIdentity>(GetFooGuidIdentityTableInfo(), provider, query);
+        }
+
         private static Query<Foo> CreateFooQuery()
             => CreateQuery<Foo>();
+
+        private static Query<FooIdentity> CreateFooIdentityQuery()
+        {
+            var query = new Query<FooIdentity>(
+                new DatabaseMapper(new ConventionModelMapper()),
+                new SqlServerQueryProvider(
+                    new SqlConnection(),
+                    new SqlServerSqlExpressionVisitorFactory(new DatabaseMapper(new ConventionModelMapper())),
+                    Substitute.For<IModelBuilder>(),
+                    new Logger(),
+                    Substitute.For<IDatabaseMapper>()));
+
+            return query;
+        }
+
+        private static Query<FooGuidIdentity> CreateFooGuidIdentityQuery()
+        {
+            var query = new Query<FooGuidIdentity>(
+                new DatabaseMapper(new ConventionModelMapper()),
+                new SqlServerQueryProvider(
+                    new SqlConnection(),
+                    new SqlServerSqlExpressionVisitorFactory(new DatabaseMapper(new ConventionModelMapper())),
+                    Substitute.For<IModelBuilder>(),
+                    new Logger(),
+                    Substitute.For<IDatabaseMapper>()));
+
+            return query;
+        }
 
         private static Query<T> CreateQuery<T>()
         {
@@ -410,41 +470,6 @@ SELECT * FROM @OutputTable;";
             return new TableInfo(columns, new List<PropertyInfo>(), null) { Name = "Foo" };
         }
 
-        private static CommandGenerator<FooPrimaryKeys> GetFooPrimaryKeyGenerator()
-        {
-            KORM.Query.IQueryProvider provider = Substitute.For<KORM.Query.IQueryProvider>();
-            provider.GetCommandForCurrentTransaction().Returns(a => { return new SqlCommand(); });
-
-            IQuery<FooPrimaryKeys> query = CreateQuery<FooPrimaryKeys>();
-            query.Select(p => new { FK1 = 1, FK2 = 2 });
-            TableInfo tableInfo = CreateTableInfoFromDto<FooPrimaryKeys>();
-            return new CommandGenerator<FooPrimaryKeys>(tableInfo, provider, query);
-        }
-
-        private static CommandGenerator<FooIdentity> GetFooIdentityGenerator()
-        {
-            KORM.Query.IQueryProvider provider = Substitute.For<KORM.Query.IQueryProvider>();
-            provider.GetCommandForCurrentTransaction().Returns(a => { return new SqlCommand(); });
-
-            IQuery<FooIdentity> query = CreateFooIdentityQuery();
-            query.Select(p => new { p.Id, p.Plat });
-            return new CommandGenerator<FooIdentity>(GetFooIdentityTableInfo(), provider, query);
-        }
-
-        private static Query<FooIdentity> CreateFooIdentityQuery()
-        {
-            var query = new Query<FooIdentity>(
-                new DatabaseMapper(new ConventionModelMapper()),
-                new SqlServerQueryProvider(
-                    new SqlConnection(),
-                    new SqlServerSqlExpressionVisitorFactory(new DatabaseMapper(new ConventionModelMapper())),
-                    Substitute.For<IModelBuilder>(),
-                    new Logger(),
-                    Substitute.For<IDatabaseMapper>()));
-
-            return query;
-        }
-
         private static TableInfo GetFooIdentityTableInfo()
         {
             var columns = new List<ColumnInfo>() {
@@ -454,6 +479,28 @@ SELECT * FROM @OutputTable;";
             };
 
             return new TableInfo(columns, new List<PropertyInfo>(), null) { Name = "FooIdentity" };
+        }
+
+        private static TableInfo GetFooGuidIdentityTableInfo()
+        {
+            var columns = new List<ColumnInfo>() {
+                new ColumnInfo() { Name = "IdRow", PropertyInfo = GetPropertyInfo<FooGuidIdentity>("Id"),
+                    IsPrimaryKey = true, AutoIncrementMethodType = AutoIncrementMethodType.Identity },
+                new ColumnInfo() { Name = "Salary", PropertyInfo = GetPropertyInfo<FooGuidIdentity>("Plat")}
+            };
+
+            return new TableInfo(columns, new List<PropertyInfo>(), null) { Name = "FooGuidIdentity" };
+        }
+
+        private static CommandGenerator<FooPrimaryKeys> GetFooPrimaryKeyGenerator()
+        {
+            KORM.Query.IQueryProvider provider = Substitute.For<KORM.Query.IQueryProvider>();
+            provider.GetCommandForCurrentTransaction().Returns(a => { return new SqlCommand(); });
+
+            IQuery<FooPrimaryKeys> query = CreateQuery<FooPrimaryKeys>();
+            query.Select(p => new { FK1 = 1, FK2 = 2 });
+            TableInfo tableInfo = CreateTableInfoFromDto<FooPrimaryKeys>();
+            return new CommandGenerator<FooPrimaryKeys>(tableInfo, provider, query);
         }
 
         private static PropertyInfo GetPropertyInfo<T>(string propertyName) => typeof(T).GetProperty(propertyName);
@@ -538,6 +585,16 @@ SELECT * FROM @OutputTable;";
             [Alias("IdRow")]
             [Key(AutoIncrementMethodType.Identity)]
             public int Id { get; set; }
+
+            [Alias("Salary")]
+            public decimal Plat { get; set; }
+        }
+
+        private class FooGuidIdentity
+        {
+            [Alias("IdRow")]
+            [Key(AutoIncrementMethodType.Identity)]
+            public Guid Id { get; set; }
 
             [Alias("Salary")]
             public decimal Plat { get; set; }

--- a/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
+++ b/tests/Kros.KORM.UnitTests/CommandGenerator/CommandGeneratorShould.cs
@@ -46,7 +46,7 @@ SELECT * FROM @OutputTable;";
         }
 
         [Fact]
-        public void HaveCorrectInsertCommandTextWhenTableHaveGuidIdentityPrimaryKey()
+        public void HaveCorrectInsertCommandTextWhenTableHasGuidIdentityPrimaryKey()
         {
             const string expectedQuery = @"DECLARE @OutputTable TABLE (IdRow uniqueidentifier);
 INSERT INTO [FooGuidIdentity] ([Salary]) OUTPUT INSERTED.IdRow INTO @OutputTable VALUES (@Salary);

--- a/tests/Kros.KORM.UnitTests/Materializer/ReaderKeyGeneratorShould.cs
+++ b/tests/Kros.KORM.UnitTests/Materializer/ReaderKeyGeneratorShould.cs
@@ -22,7 +22,7 @@ namespace Kros.KORM.UnitTests.Materializer
         }
 
         [Fact]
-        public void ReturnSameKeyForReadersWhitSameColumns()
+        public void ReturnSameKeyForReadersWithSameColumns()
         {
             Reader reader1 = new Reader(CreateListOfColumns());
             Reader reader2 = new Reader(CreateListOfColumns());
@@ -35,7 +35,7 @@ namespace Kros.KORM.UnitTests.Materializer
         }
 
         [Fact]
-        public void ReturnDifferentKeyForReadersWhitDifferentColumns()
+        public void ReturnDifferentKeyForReadersWithDifferentColumns()
         {
             Reader reader1 = new Reader(CreateListOfColumns());
             Reader reader2 = new Reader(new List<Tuple<string, Type>>() { new Tuple<string, Type>("FirstName", typeof(string)),
@@ -50,7 +50,7 @@ namespace Kros.KORM.UnitTests.Materializer
         }
 
         [Fact]
-        public void ReturnSameKeyForReadersWhitSameColumnsWhenChangeLetterCase()
+        public void ReturnSameKeyForReadersWithSameColumnsWhenChangeLetterCase()
         {
             Reader reader1 = new Reader(CreateListOfColumns());
             Reader reader2 = new Reader(new List<Tuple<string, Type>>() { new Tuple<string, Type>("ID", typeof(Int32)),
@@ -65,7 +65,7 @@ namespace Kros.KORM.UnitTests.Materializer
         }
 
         [Fact]
-        public void ReturnDifferentKeysForReadersWhitSameColumnsAndOtherDataTypes()
+        public void ReturnDifferentKeysForReadersWithSameColumnsAndOtherDataTypes()
         {
             Reader reader1 = new Reader(CreateListOfColumns());
             Reader reader2 = new Reader(CreateListOfColumns());


### PR DESCRIPTION
Closes #118.

Apart of supporting sequential GUIDs generation by SQL and its unit tests (as described in #118 ), few typos were corrected.