### PR TITLE
SkipNullValues

### DIFF
--- a/src/Kros.KORM.csproj
+++ b/src/Kros.KORM.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
-    <Version>5.2.0</Version>
+    <Version>5.2.1</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>KORM is fast, easy to use, micro ORM tool (Kros Object Relation Mapper).</Description>

--- a/src/Materializer/DynamicMethodModelFactory.cs
+++ b/src/Materializer/DynamicMethodModelFactory.cs
@@ -20,6 +20,21 @@ namespace Kros.KORM.Materializer
     /// <seealso cref="IModelFactory" />
     public class DynamicMethodModelFactory : IModelFactory
     {
+        /// <summary>
+        /// When set to <see langword="true"/>, a DB <c>NULL</c> value does NOT overwrite the model property.
+        /// The property setter (and any converter) is skipped, so the property keeps the value assigned
+        /// in the constructor / its CLR default. This restores the KORM 4.x behavior and prevents
+        /// <see cref="NullReferenceException"/> for converters that do not handle <see langword="null"/>
+        /// on non-nullable value types.
+        /// The default is <see langword="false"/> (KORM 5.x behavior: the setter is always called and
+        /// a DB <c>NULL</c> is materialized as the type default).
+        /// </summary>
+        /// <remarks>
+        /// Set this once during application startup, before the first query is executed. Materialization
+        /// delegates are cached, so changing the value afterwards does not affect already-built factories.
+        /// </remarks>
+        public static bool SkipNullValues { get; set; }
+
         #region Private fields
 
         private readonly IDatabaseMapper _databaseMapper;
@@ -166,18 +181,29 @@ namespace Kros.KORM.Materializer
             ColumnInfo columnInfo = tableInfo.GetColumnInfo(reader.GetName(columnIndex));
             if (columnInfo != null)
             {
-                ilGenerator.LogAndEmit(OpCodes.Ldloc_0);
                 Type srcType = reader.GetFieldType(columnIndex);
                 IConverter converter = ConverterHelper.GetConverter(columnInfo, srcType);
-                if (converter is null)
+                Type propertyType = columnInfo.PropertyInfo.PropertyType;
+                MethodInfo setter = columnInfo.PropertyInfo.GetSetMethod(true);
+
+                if (SkipNullValues)
                 {
-                    ilGenerator.EmitFieldWithoutConverter(srcType, columnInfo.PropertyInfo.PropertyType, columnIndex);
+                    // KORM 4.x behavior: on DB NULL do not touch the property at all.
+                    ilGenerator.EmitFieldSkipNull(converter, srcType, propertyType, columnIndex, setter);
                 }
                 else
                 {
-                    ilGenerator.EmitFieldWithConverter(converter, columnInfo.PropertyInfo.PropertyType, columnIndex);
+                    ilGenerator.LogAndEmit(OpCodes.Ldloc_0);
+                    if (converter is null)
+                    {
+                        ilGenerator.EmitFieldWithoutConverter(srcType, propertyType, columnIndex);
+                    }
+                    else
+                    {
+                        ilGenerator.EmitFieldWithConverter(converter, propertyType, columnIndex);
+                    }
+                    ilGenerator.LogAndEmit(OpCodes.Callvirt, setter);
                 }
-                ilGenerator.LogAndEmit(OpCodes.Callvirt, columnInfo.PropertyInfo.GetSetMethod(true));
             }
         }
 

--- a/src/Materializer/ILGeneratorHelper.cs
+++ b/src/Materializer/ILGeneratorHelper.cs
@@ -150,6 +150,42 @@ namespace Kros.KORM.Materializer
             ilGenerator.MarkLabel(labelEnd);
         }
 
+        /// <summary>
+        /// Emits code which sets the property only when the reader value is NOT DB NULL.
+        /// When the value is DB NULL, the property setter (and any converter) is skipped entirely,
+        /// so the property keeps the value assigned in the constructor / its CLR default.
+        /// This mirrors the KORM 4.x behavior.
+        /// </summary>
+        public static void EmitFieldSkipNull(
+            this ILGenerator ilGenerator,
+            IConverter converter,
+            Type srcType,
+            Type propertyType,
+            int columnIndex,
+            MethodInfo setter)
+        {
+            // Emit: if (reader.IsDbNull(columnIndex)) { /* do nothing */ }
+            Label labelEnd = ilGenerator.DefineLabel();
+            ilGenerator.LogAndEmit(OpCodes.Ldarg_0);
+            ilGenerator.LogAndEmit(OpCodes.Ldc_I4, columnIndex);
+            ilGenerator.LogAndEmit(OpCodes.Callvirt, _fnIsDBNull);
+            ilGenerator.LogAndEmit(OpCodes.Brtrue, labelEnd);
+
+            // Emit: else { target.Property = <value from reader>; }
+            ilGenerator.LogAndEmit(OpCodes.Ldloc_0);
+            if (converter is null)
+            {
+                ilGenerator.CallReaderGetValueWithoutConverter(columnIndex, propertyType, srcType);
+            }
+            else
+            {
+                ilGenerator.CallConverter(converter, propertyType, columnIndex, convertNullValue: false);
+            }
+            ilGenerator.LogAndEmit(OpCodes.Callvirt, setter);
+
+            ilGenerator.MarkLabel(labelEnd);
+        }
+
         private static ILGenerator CallReaderMethod(
             this ILGenerator ilGenerator,
             int fieldIndex,

--- a/tests/Kros.KORM.UnitTests/Materializer/MethodModelFactoryShould.cs
+++ b/tests/Kros.KORM.UnitTests/Materializer/MethodModelFactoryShould.cs
@@ -65,6 +65,162 @@ namespace Kros.KORM.UnitTests.Materializer
         }
 
         [Fact]
+        public void SkipSettingPropertiesForDbNullWhenSkipNullValuesEnabled()
+        {
+            DynamicMethodModelFactory.SkipNullValues = true;
+            try
+            {
+                DynamicMethodModelFactory factory = CreateFactory();
+                var rows = CreateData();
+                // Column with a converter that is not null-safe (TestEnumConverter calls value.ToString()).
+                rows[0].Add("PropertyEnumConv", "V2");
+                using InMemoryDataReader data = new InMemoryDataReader(rows);
+                data.Read();
+
+                data.CurrentValues[2] = DBNull.Value; // Something -> non-nullable PropertyDouble
+                data.CurrentValues[data.GetOrdinal("PropertyEnumConv")] = DBNull.Value;
+
+                var fact = factory.GetFactory<Foo>(data);
+
+                // Must not throw NullReferenceException even though the converter is not null-safe.
+                var foo = fact(data);
+
+                // DB NULL does not overwrite the property; it keeps its CLR default (v4.x behavior).
+                foo.PropertyDouble.Should().Be(0);
+                foo.PropertyEnumConv.Should().Be(default(TestEnum));
+            }
+            finally
+            {
+                DynamicMethodModelFactory.SkipNullValues = false;
+            }
+        }
+
+        [Fact]
+        public void ThrowForDbNullWithNullUnsafeConverterWhenSkipNullValuesDisabled()
+        {
+            // Default (v5.x) behavior: the converter is invoked with null for DB NULL,
+            // so a converter that is not null-safe throws. Documents why SkipNullValues exists.
+            DynamicMethodModelFactory factory = CreateFactory();
+            var rows = CreateData();
+            rows[0].Add("PropertyEnumConv", "V2");
+            using InMemoryDataReader data = new InMemoryDataReader(rows);
+            data.Read();
+
+            data.CurrentValues[data.GetOrdinal("PropertyEnumConv")] = DBNull.Value;
+
+            var fact = factory.GetFactory<Foo>(data);
+
+            ((Action)(() => fact(data))).Should().Throw<NullReferenceException>();
+        }
+
+        [Fact]
+        public void KeepConstructorValueForDbNullWhenSkipNullValuesEnabled()
+        {
+            DynamicMethodModelFactory.SkipNullValues = true;
+            try
+            {
+                DynamicMethodModelFactory factory = CreateCtorModelFactory();
+                var rows = new List<Dictionary<string, object>>
+                {
+                    new Dictionary<string, object> { { "Value", 999 }, { "Name", "fromDb" }, { "NullableValue", 999 } }
+                };
+                using InMemoryDataReader data = new InMemoryDataReader(rows);
+                data.Read();
+                data.CurrentValues[0] = DBNull.Value; // Value (non-nullable int) -> NULL
+                data.CurrentValues[1] = DBNull.Value; // Name (reference type) -> NULL
+                data.CurrentValues[2] = DBNull.Value; // NullableValue (int?) -> NULL
+
+                var fact = factory.GetFactory<CtorDefaultModel>(data);
+                CtorDefaultModel obj = fact(data);
+
+                // DB NULL does not overwrite -> values assigned in the constructor are kept.
+                obj.Value.Should().Be(42);
+                obj.Name.Should().Be("init");
+                obj.NullableValue.Should().Be(7);
+            }
+            finally
+            {
+                DynamicMethodModelFactory.SkipNullValues = false;
+            }
+        }
+
+        [Fact]
+        public void OverwriteConstructorValueWithDefaultForDbNullWhenSkipNullValuesDisabled()
+        {
+            // Default (v5.x) behavior: DB NULL overwrites the property with the type default,
+            // losing the value assigned in the constructor.
+            DynamicMethodModelFactory factory = CreateCtorModelFactory();
+            var rows = new List<Dictionary<string, object>>
+            {
+                new Dictionary<string, object> { { "Value", 999 }, { "Name", "fromDb" }, { "NullableValue", 999 } }
+            };
+            using InMemoryDataReader data = new InMemoryDataReader(rows);
+            data.Read();
+            data.CurrentValues[0] = DBNull.Value;
+            data.CurrentValues[1] = DBNull.Value;
+            data.CurrentValues[2] = DBNull.Value;
+
+            var fact = factory.GetFactory<CtorDefaultModel>(data);
+            CtorDefaultModel obj = fact(data);
+
+            // Reference and nullable value types are overwritten with null...
+            obj.Name.Should().BeNull();
+            obj.NullableValue.Should().BeNull();
+            // ...and non-nullable value types with the type default (no crash without a converter).
+            obj.Value.Should().Be(0);
+        }
+
+        [Fact]
+        public void ThrowForDbNullOnNonNullableValueTypeWithConverterWhenSkipNullValuesDisabled()
+        {
+            // Default (v5.x) behavior: the converter is invoked with null for DB NULL and returns null.
+            // Assigning null to a NON-NULLABLE value-type property (Unbox_Any on null) throws.
+            DynamicMethodModelFactory factory = CreateFactoryFor<ConverterModel>(
+                new ColumnInfo()
+                {
+                    Name = "NonNullableWithConverter",
+                    PropertyInfo = GetPropertyInfo<ConverterModel>("NonNullableWithConverter"),
+                    Converter = new ReturnNullConverter()
+                });
+            var rows = new List<Dictionary<string, object>>
+            {
+                new Dictionary<string, object> { { "NonNullableWithConverter", 1 } }
+            };
+            using InMemoryDataReader data = new InMemoryDataReader(rows);
+            data.Read();
+            data.CurrentValues[0] = DBNull.Value;
+
+            var fact = factory.GetFactory<ConverterModel>(data);
+
+            ((Action)(() => fact(data))).Should().Throw<NullReferenceException>();
+        }
+
+        [Fact]
+        public void SetNullForDbNullOnNullableValueTypeWithConverterWhenSkipNullValuesDisabled()
+        {
+            // Same converter returning null, but a NULLABLE property: assigning null succeeds (no crash).
+            DynamicMethodModelFactory factory = CreateFactoryFor<ConverterModel>(
+                new ColumnInfo()
+                {
+                    Name = "NullableWithConverter",
+                    PropertyInfo = GetPropertyInfo<ConverterModel>("NullableWithConverter"),
+                    Converter = new ReturnNullConverter()
+                });
+            var rows = new List<Dictionary<string, object>>
+            {
+                new Dictionary<string, object> { { "NullableWithConverter", 1 } }
+            };
+            using InMemoryDataReader data = new InMemoryDataReader(rows);
+            data.Read();
+            data.CurrentValues[0] = DBNull.Value;
+
+            var fact = factory.GetFactory<ConverterModel>(data);
+            ConverterModel obj = fact(data);
+
+            obj.NullableWithConverter.Should().BeNull();
+        }
+
+        [Fact]
         public void CreateFactoryWhichKnowFillingObjectsWithEnums()
         {
             DynamicMethodModelFactory factory = CreateFactory();
@@ -340,6 +496,23 @@ namespace Kros.KORM.UnitTests.Materializer
             return modelMapper;
         }
 
+        private DynamicMethodModelFactory CreateCtorModelFactory()
+            => CreateFactoryFor<CtorDefaultModel>(
+                new ColumnInfo() { Name = "Value", PropertyInfo = GetPropertyInfo<CtorDefaultModel>("Value") },
+                new ColumnInfo() { Name = "Name", PropertyInfo = GetPropertyInfo<CtorDefaultModel>("Name") },
+                new ColumnInfo() { Name = "NullableValue", PropertyInfo = GetPropertyInfo<CtorDefaultModel>("NullableValue") });
+
+        private DynamicMethodModelFactory CreateFactoryFor<T>(params ColumnInfo[] columns)
+        {
+            TableInfo tableInfo = new TableInfo(columns, columns.Select(p => p.PropertyInfo), null);
+
+            var modelMapper = Substitute.For<IModelMapper>();
+            modelMapper.GetTableInfo<T>().Returns(tableInfo);
+            modelMapper.GetTableInfo(Arg.Any<Type>()).Returns(tableInfo);
+
+            return CreateFactory(modelMapper);
+        }
+
         private TableInfo CreateTableInfo()
         {
             List<ColumnInfo> columns = new List<ColumnInfo>() {
@@ -479,6 +652,37 @@ namespace Kros.KORM.UnitTests.Materializer
 
             [NoMap()]
             public TestService Service { get; set; }
+        }
+
+        private class CtorDefaultModel
+        {
+            public CtorDefaultModel()
+            {
+                Value = 42;
+                Name = "init";
+                NullableValue = 7;
+            }
+
+            public int Value { get; set; }
+
+            public string Name { get; set; }
+
+            public int? NullableValue { get; set; }
+        }
+
+        // Converter that passes the value through unchanged, i.e. returns null for a DB NULL.
+        private class ReturnNullConverter : IConverter
+        {
+            public object Convert(object value) => value;
+
+            public object ConvertBack(object value) => value;
+        }
+
+        private class ConverterModel
+        {
+            public int NonNullableWithConverter { get; set; }
+
+            public int? NullableWithConverter { get; set; }
         }
 
         public class TestService


### PR DESCRIPTION
  ## Problém
  Od #97 (vydané v 5.0.0) sa pri DB NULL vždy zavolá setter property:
  non-nullable hodnotové typy dostanú default typu (napr. `int` → 0) a konvertor
  sa zavolá s `null`. Ak konvertor pre `null` vráti `null` a cieľová property je
  non-nullable hodnotový typ, `Unbox_Any` nad `null` vyhodí `NullReferenceException`.
  Oproti verzii 4.x je to zmena správania — tam sa pri NULL setter preskočil a
  zachovala sa hodnota z konštruktora / default.

  ## Zmena
  Pridáva voliteľný statický prepínač `DynamicMethodModelFactory.SkipNullValues`
  (default `false` = súčasné 5.x správanie). Keď je `true`, DB NULL úplne preskočí
  setter property (aj konvertor) — čím sa obnoví správanie 4.x: zachová sa hodnota
  nastavená v konštruktore / CLR default.

  Nastavuje sa raz pri štarte aplikácie (materializačné delegáty sa cachujú):
  `DynamicMethodModelFactory.SkipNullValues = true;`

  ## Testy
  - pri zapnutom prepínači sa pri NULL zachová hodnota z konštruktora / default;
  - referenčné a nullable hodnotové typy sa bez prepínača prepíšu na `null` (nezmenené);
  - non-nullable hodnotový typ + konvertor vracajúci `null` → bez prepínača `NullReferenceException`,
    so zapnutým prepínačom bez pádu.