### PR TITLE
Turn of parallelization in tests

### DIFF
--- a/tests/Kros.KORM.UnitTests/Kros.KORM.UnitTests.csproj
+++ b/tests/Kros.KORM.UnitTests/Kros.KORM.UnitTests.csproj
@@ -28,6 +28,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- QueryProviderFactories uses a process-wide static registry that these tests mutate and
+         assert on. xUnit runs test collections in parallel by default, which races against that
+         shared state (see QueryProviderFactoriesShould). Disable parallelization for determinism. -->
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="Resources\AnotherSqlScripts\20190227001_InitDatabase.sql" />
     <None Remove="Resources\AnotherSqlScripts\20190227002_AddProjectTable.sql" />
     <None Remove="Resources\AnotherSqlScripts\20190227003_Script_with_separator.sql" />

--- a/tests/Kros.KORM.UnitTests/xunit.runner.json
+++ b/tests/Kros.KORM.UnitTests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
We have a reace condition in tests and so some tests are randomly failing because of parallelization.

