### PR TITLE
Fix raw SQL parameter parsing when SQL line endings do not match the host platform

### DIFF
--- a/src/Query/Sql/ParamEnumerator.cs
+++ b/src/Query/Sql/ParamEnumerator.cs
@@ -1,5 +1,4 @@
 ﻿using Kros.Utils;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -15,7 +14,7 @@ namespace Kros.KORM.Query.Sql
         public ParamEnumerator(string sql)
         {
             Check.NotNullOrWhiteSpace(sql, nameof(sql));
-            _sql = sql.Replace(Environment.NewLine, " ");
+            _sql = sql.Replace('\r', ' ').Replace('\n', ' ').Replace('\t', ' ');
             _sql = _sql.Replace("(", " ");
             _sql = _sql.Replace(")", " ");
         }

--- a/tests/Kros.KORM.UnitTests/Query/Sql/ParameterExtractingExpressionVisitorShould.cs
+++ b/tests/Kros.KORM.UnitTests/Query/Sql/ParameterExtractingExpressionVisitorShould.cs
@@ -99,6 +99,66 @@ namespace Kros.KORM.UnitTests.Query.Sql
         }
 
         [Fact]
+        public void ExtractParamsFromSqlExpressionWithLfLineEndings()
+        {
+            var connection = new SqlConnection();
+            var database = new Database(connection);
+
+            var query = database.Query<Person>()
+                .Sql("Select * from Person where Id = @Id\n\tAND Age > @Age\nORDER BY Name", 1, 18);
+            var command = connection.CreateCommand();
+
+            ParameterExtractingExpressionVisitor.ExtractParametersToCommand(command, query.Expression);
+
+            Assert.Equal(2, command.Parameters.Count);
+            Assert.Equal("@Id", command.Parameters[0].ParameterName);
+            Assert.Equal(1, command.Parameters[0].Value);
+
+            Assert.Equal("@Age", command.Parameters[1].ParameterName);
+            Assert.Equal(18, command.Parameters[1].Value);
+        }
+
+        [Fact]
+        public void ExtractParamsFromSqlExpressionWithCrLfLineEndings()
+        {
+            var connection = new SqlConnection();
+            var database = new Database(connection);
+
+            var query = database.Query<Person>()
+                .Sql("Select * from Person where Id = @Id\r\n\tAND Age > @Age\r\nORDER BY Name", 1, 18);
+            var command = connection.CreateCommand();
+
+            ParameterExtractingExpressionVisitor.ExtractParametersToCommand(command, query.Expression);
+
+            Assert.Equal(2, command.Parameters.Count);
+            Assert.Equal("@Id", command.Parameters[0].ParameterName);
+            Assert.Equal(1, command.Parameters[0].Value);
+
+            Assert.Equal("@Age", command.Parameters[1].ParameterName);
+            Assert.Equal(18, command.Parameters[1].Value);
+        }
+
+        [Fact]
+        public void ExtractParamsFromSqlExpressionWithTabAfterParameter()
+        {
+            var connection = new SqlConnection();
+            var database = new Database(connection);
+
+            var query = database.Query<Person>()
+                .Sql("Select * from Person where Id = @Id\tAND Age > @Age", 1, 18);
+            var command = connection.CreateCommand();
+
+            ParameterExtractingExpressionVisitor.ExtractParametersToCommand(command, query.Expression);
+
+            Assert.Equal(2, command.Parameters.Count);
+            Assert.Equal("@Id", command.Parameters[0].ParameterName);
+            Assert.Equal(1, command.Parameters[0].Value);
+
+            Assert.Equal("@Age", command.Parameters[1].ParameterName);
+            Assert.Equal(18, command.Parameters[1].Value);
+        }
+
+        [Fact]
         public void ExtractParamsFromSqlExpressionWithInOperator()
         {
             var connection = new SqlConnection();


### PR DESCRIPTION
Closes #130

## Problem

`ParamEnumerator` (used by `ParameterExtractingExpressionVisitor` and `QueryProvider.ExecuteNonQueryAsync` to extract parameter names from raw SQL) normalizes line endings with:

```csharp
_sql = sql.Replace(Environment.NewLine, " ");
```

and then treats only space, `,` and `)` as token delimiters.

Parameter name extraction therefore silently depends on the SQL string's line endings matching the host platform's `Environment.NewLine`. When they do not match, a parameter followed by a line break produces a broken parameter name.

### Real-world scenario

Our repository switched to `*.cs text eol=lf` in `.gitattributes`. Verbatim/raw SQL string literals compiled in CI now contain bare `\n`. On a Windows host (`Environment.NewLine == "\r\n"`) this SQL:

```csharp
private const string Sql = @"
SELECT ...
FROM MovementsHistory
WHERE
	CompanyId = @1
	AND MovementDate < @2";

_database.Query<Row>().Sql(Sql, companyId, date);
```

produces a parameter named `"@1\n\tAND"` — the token runs to the first space, and the final `Trim()` cannot remove the embedded `\n\t`. The command is executed with a parameter collection that does not contain `@1`, and SQL Server fails with:

> Must declare the scalar variable "@1".

This hit us in production after the line-endings switch. A few observations:

- The bug is invisible in local development: working copies checked out before the `.gitattributes` change still have CRLF, so only CI-built binaries are affected.
- The existing test `ExtractParamsFromSqlExpressionWithEnter` cannot catch this, because the line endings of its verbatim literal always follow the checkout, which follows the platform — so they always match `Environment.NewLine`.
- A parameter followed directly by a TAB (`WHERE Id = @1\tAND ...`) is broken the same way on **every** platform.
- The reverse mismatch (CRLF SQL on a Linux host) survives only by accident: the leftover `\r` ends up at the end of the token and is removed by `Trim()`.

## Fix

Replace `\r`, `\n` and `\t` characters individually, so tokenization no longer depends on the host platform:

```csharp
_sql = sql.Replace('\r', ' ').Replace('\n', ' ').Replace('\t', ' ');
```

This also fixes the TAB-after-parameter case.

## Tests

Added three tests using explicit escape sequences (`\n`, `\r\n`, `\t`) — deliberately not verbatim literals, so they exercise all line-ending variants regardless of checkout or platform:

- `ExtractParamsFromSqlExpressionWithLfLineEndings` — failed before the fix on Windows (`@Id\n\tAND`)
- `ExtractParamsFromSqlExpressionWithCrLfLineEndings` — guards the reverse mismatch on Linux hosts
- `ExtractParamsFromSqlExpressionWithTabAfterParameter` — failed before the fix on every platform (`@Id\tAND`)

Full unit test suite shows no regressions: the `Integration.*` tests requiring a Docker SQL Server fail identically with and without this change on my machine (environment only); all runnable tests pass.